### PR TITLE
Enforce deterministic formatting with Ktfmt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("com.android.application").version("7.1.1").apply(false)
   id("com.android.library").version("7.1.1").apply(false)
+  id("com.ncorti.ktfmt.gradle").version("0.8.0").apply(false)
   id("org.jetbrains.kotlin.android").version("1.6.10").apply(false)
 }
 

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("com.android.application")
+  id("com.ncorti.ktfmt.gradle")
   id("org.jetbrains.kotlin.android")
   id("jacoco")
 }


### PR DESCRIPTION
As discussed in today's meeting, Ktfmt is available as a Gradle plugin which adds some tasks to enforce deterministic code formatting.

Ktfmt is also available as a convenience plugin for Android Studio, which overrides the default IDE formatting.

- Ktfmt : https://github.com/facebookincubator/ktfmt
- Ktfmt Gradle plugin : https://github.com/cortinico/ktfmt-gradle