### PR TITLE
Deploy the wiki from the `/wiki` folder

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,28 @@
+name: Publish wiki
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.TOKEN_GITHUB }}
+
+      - name: Update Wiki
+        run : |
+          cd wiki/
+          git init .
+          git config user.name "${{github.actor}}"
+          git config user.email "${{github.actor}}@users.noreply.github.com"
+          git add .
+          git commit -m "Deployed wiki 🚀"
+          git remote add origin https://${{secrets.TOKEN_GITHUB}}@github.com/${{github.repository}}.wiki.git
+          git push -u origin master --force
+

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,41 @@
+# Pawnies' Wiki !
+
+You can find here information about the organization and the workflow of this repo!
+
+# Workflow
+
+## Naming convention
+- All branches must follow this structure : `type\initial\branch_name`
+   - The `type` can be : `feature`, `fix`
+   - Each contributor has an initial, you can find this information at the end of this section
+   - The `branch_name` must be meaningful and be separated by an underscore
+
+| Name                 | Initial |
+|----------------------|---------|
+| Lars Barmettler      | |
+| Matthieu Burguburu   | |
+| Chau Ying Kot        | CYK |
+| Fouad Mahmoud        | |
+| Alexandre Piveteau   | AP |
+| Mohamed Badr Taddist | BT |
+
+## Pull request
+
+- Each PR must be linked to the corresponding issue. 
+- You can use the Draft PR, if you want an early review
+- For the reviewer, you can prefix your comments with a keyword that indicating the kind of comment it is, here is a short list of keywords : 
+   - Important
+   - Nitpick
+   - Question
+   - Bug
+   - Proposition
+
+# Meeting
+
+Each week, we have 2 stand-up meetings :
+- Tuesday at 12:45
+- Thursday at 12:45
+
+In addition to the stand-up, we have a sprint review with our TAs Friday at 11:15. At the end of this meeting, the Scrum Team will plan the content of the next sprint backlog.
+
+

--- a/wiki/Sprint-1.md
+++ b/wiki/Sprint-1.md
@@ -1,0 +1,11 @@
+# Sprint 1
+
+## Lars Barmettler 
+
+## Matthieu Burguburu
+
+## Chau Ying Kot
+
+## Alexandre Piveteau
+
+## Mohamed Badr Taddist


### PR DESCRIPTION
This PR takes the content of the wiki (commit `ec93ac5f8ba58c199f27d5818b16318d5454bb67`) and adds it to this repo. A GitHub Action Workflow which deploys the wiki on pushes to the `main` branch is also added.