### PR TITLE
Add a generic `DocumentReference.set` method

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/backend/store/fake/DslTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/backend/store/fake/DslTest.kt
@@ -92,6 +92,14 @@ class DslTest {
   }
 
   @Test
+  fun document_setWithKeyValues() = runTest {
+    val store = emptyStore()
+    store.collection("users").document("alexandre").set(mapOf("name" to "Alexandre"))
+    val data = store.collection("users").document("alexandre").asFlow<User>().first()
+    assertThat(data).isEqualTo(alexandre)
+  }
+
+  @Test
   fun document_supportsPartialUpdate() = runTest {
     val store = buildStore { collection("users") { document("doc", SampleDocument()) } }
     store.collection("users").document("doc").update {

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/backend/store/fake/DslTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/backend/store/fake/DslTest.kt
@@ -1,6 +1,7 @@
 package ch.epfl.sdp.mobile.backend.store.fake
 
 import ch.epfl.sdp.mobile.backend.store.asFlow
+import ch.epfl.sdp.mobile.backend.store.set
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -80,6 +81,14 @@ class DslTest {
     val data = store.collection("users").document("doc").asFlow<SampleDocument>().first()
 
     assertThat(data).isEqualTo(SampleDocument(title = "Hello", subtitle = null))
+  }
+
+  @Test
+  fun document_supportsSetWithClass() = runTest {
+    val store = emptyStore()
+    store.collection("users").document("alexandre").set(alexandre)
+    val data = store.collection("users").document("alexandre").asFlow<User>().first()
+    assertThat(data).isEqualTo(alexandre)
   }
 
   @Test

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/backend/store/fake/impl/FakeDocumentReference.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/backend/store/fake/impl/FakeDocumentReference.kt
@@ -28,6 +28,10 @@ class FakeDocumentReference : DocumentReference, CollectionBuilder {
     record.update { FakeDocumentRecord().update(scope) }
   }
 
+  override suspend fun <T : Any> set(value: T, valueClass: KClass<T>) {
+    record.update { FakeDocumentRecord.fromObject(value, valueClass) }
+  }
+
   override suspend fun update(scope: DocumentEditScope.() -> Unit) {
     record.update { (it ?: FakeDocumentRecord()).update(scope) }
   }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/backend/store/firestore/FirestoreDocumentReferenceTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/backend/store/firestore/FirestoreDocumentReferenceTest.kt
@@ -1,6 +1,7 @@
 package ch.epfl.sdp.mobile.backend.store.firestore
 
 import ch.epfl.sdp.mobile.backend.store.asFlow
+import ch.epfl.sdp.mobile.backend.store.set
 import com.google.android.gms.tasks.Tasks
 import com.google.common.truth.Truth
 import com.google.firebase.firestore.*
@@ -105,5 +106,21 @@ class FirestoreDocumentReferenceTest {
     reference.set { this["key"] = "value" }
 
     verify { doc.set(mapOf("key" to "value")) }
+  }
+
+  data class TestDocument(
+      val name: String? = null,
+  )
+
+  @Test
+  fun setFromClass_callsApiWithRightArguments() = runTest {
+    val doc = mockk<DocumentReference>()
+    val reference = FirestoreDocumentReference(doc)
+    val sample = TestDocument("Hello")
+    every { doc.set(sample) } returns Tasks.forResult(null)
+
+    reference.set(sample)
+
+    verify { doc.set(sample) }
   }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/backend/store/DocumentReference.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/backend/store/DocumentReference.kt
@@ -70,3 +70,15 @@ inline fun <reified T : Any> DocumentReference.asFlow(): Flow<T?> = asFlow(T::cl
  * @param value hte value of the document which should be set. Existing fields will be discarded.
  */
 suspend inline fun <reified T : Any> DocumentReference.set(value: T): Unit = set(value, T::class)
+
+/**
+ * Sets the given document with the provided [values].
+ *
+ * @receiver the [DocumentReference] onto which the items will be set.
+ * @param values the [Map] of the values which will be set to the document.
+ */
+suspend fun DocumentReference.set(values: Map<String, Any?>) = set {
+  for ((key, value) in values) {
+    this[key] = value
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/backend/store/DocumentReference.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/backend/store/DocumentReference.kt
@@ -38,6 +38,15 @@ interface DocumentReference {
   suspend fun set(scope: DocumentEditScope.() -> Unit)
 
   /**
+   * Sets the given document with the provided [value].
+   *
+   * @param T the type of the document.
+   * @param value the value of the document which should be set. Existing fields will be discarded.
+   * @param valueClass the [KClass] of the item that is set.
+   */
+  suspend fun <T : Any> set(value: T, valueClass: KClass<T>)
+
+  /**
    * Updates the given document within the [scope].
    *
    * @param scope the [DocumentEditScope] in which editing operations are taking place. Existing
@@ -53,3 +62,11 @@ interface DocumentReference {
  * @return the [Flow] of the document values.
  */
 inline fun <reified T : Any> DocumentReference.asFlow(): Flow<T?> = asFlow(T::class)
+
+/**
+ * Sets the given document with the provided [value].
+ *
+ * @param T the type of the document.
+ * @param value hte value of the document which should be set. Existing fields will be discarded.
+ */
+suspend inline fun <reified T : Any> DocumentReference.set(value: T) = set(value, T::class)

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/backend/store/DocumentReference.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/backend/store/DocumentReference.kt
@@ -69,4 +69,4 @@ inline fun <reified T : Any> DocumentReference.asFlow(): Flow<T?> = asFlow(T::cl
  * @param T the type of the document.
  * @param value hte value of the document which should be set. Existing fields will be discarded.
  */
-suspend inline fun <reified T : Any> DocumentReference.set(value: T) = set(value, T::class)
+suspend inline fun <reified T : Any> DocumentReference.set(value: T): Unit = set(value, T::class)

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/backend/store/firestore/FirestoreDocumentReference.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/backend/store/firestore/FirestoreDocumentReference.kt
@@ -50,4 +50,8 @@ class FirestoreDocumentReference(
     val values = FirestoreDocumentEditScope().apply(scope).values
     reference.set(values).await()
   }
+
+  override suspend fun <T : Any> set(value: T, valueClass: KClass<T>) {
+    reference.set(value).await()
+  }
 }


### PR DESCRIPTION
This PR builds on top of #56 and adds support for `DocumentReference.set`, which takes a data class and stores it as a document.