### PR TITLE
Fix `Modifier.shadow` being applied in the wrong order

### DIFF
--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/features/profile/ProfileStateScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/features/profile/ProfileStateScreen.kt
@@ -136,9 +136,9 @@ fun ProfilePicture(
         onClick = state::onEditClick,
         modifier =
             Modifier.align(Alignment.BottomEnd)
+                .shadow(2.dp, CircleShape)
                 .background(MaterialTheme.colors.surface, CircleShape)
                 .border(2.dp, MaterialTheme.colors.primary, CircleShape)
-                .shadow(2.dp, CircleShape)
                 .size(40.dp),
     ) { Icon(Icons.Default.Edit, "Edit profile icon") }
   }


### PR DESCRIPTION
This resulted in the shadow being drawn on top of the background of the button, rather than behind it (so only a minor visual issue).