### PR TITLE
Implement authentication mocking

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/Dsl.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/Dsl.kt
@@ -1,0 +1,32 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.auth
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.fake.FakeAuth
+
+/** Creates an in-memory implementation of [Auth], which can't fail. */
+fun emptyAuth(): Auth = FakeAuth()
+
+/**
+ * Builds an [Auth] using the provided [AuthBuilder].
+ *
+ * @param builder the builder for the auth.
+ * @return the newly build fake auth.
+ */
+fun buildAuth(
+    builder: AuthBuilder.() -> Unit,
+): Auth = FakeAuth().apply(builder)
+
+/**
+ * A scope which can be used to create some users and perform some actions on an
+ * [ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth] instance.
+ */
+interface AuthBuilder {
+
+  /**
+   * Adds a new user with the given email and password.
+   *
+   * @param email the email of the added user. Must be unique for this auth.
+   * @param password the password which will protect authentication with the account.
+   */
+  fun user(email: String, password: String)
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/DslTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/DslTest.kt
@@ -1,0 +1,69 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.auth
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth.AuthenticationResult.FailureInternal
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth.AuthenticationResult.Success
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DslTest {
+
+  @Test
+  fun emptyAuth_hasCurrentUser() = runTest {
+    val auth = emptyAuth()
+    val user = auth.currentUser.first()
+
+    assertThat(user).isNull()
+  }
+
+  @Test
+  fun emptyAuth_cantSignIn() = runTest {
+    val auth = emptyAuth()
+    val result = auth.signInWithEmail("email", "password")
+
+    assertThat(result).isEqualTo(FailureInternal)
+  }
+
+  @Test
+  fun existingUser_canSignIn() = runTest {
+    val auth = buildAuth { user("alexandre.piveteau@epfl.ch", "password") }
+    val result = auth.signInWithEmail("alexandre.piveteau@epfl.ch", "password")
+
+    assertThat(result).isInstanceOf(Success::class.java)
+  }
+
+  @Test
+  fun existingUser_cantSignUp() = runTest {
+    val auth = buildAuth { user("alexandre.piveteau@epfl.ch", "password") }
+    val result = auth.signUpWithEmail("alexandre.piveteau@epfl.ch", "password")
+
+    assertThat(result).isEqualTo(FailureInternal)
+  }
+
+  @Test
+  fun signUp_makesUserCurrent() = runTest {
+    val auth = emptyAuth()
+    val result = auth.signUpWithEmail("alexandre.piveteau@epfl.ch", "password") as Success
+    val current = auth.currentUser.first()
+
+    assertThat(result.user).isEqualTo(current)
+  }
+
+  @Test
+  fun canSignIn_afterSignUp() = runTest {
+    val auth = buildAuth { user("alexandre.piveteau@epfl.ch", "password") }
+    auth.signUpWithEmail("john.cena@epfl.ch", "password")
+    val result = auth.signInWithEmail("alexandre.piveteau@epfl.ch", "password") as Success
+
+    assertThat(auth.currentUser.first()).isEqualTo(result.user)
+  }
+
+  @Test
+  fun cantSignIn_withBadPassword() = runTest {
+    val auth = buildAuth { user("alexandre.piveteau@epfl.ch", "password") }
+    val result = auth.signInWithEmail("alexandre.piveteau@epfl.ch", "bad")
+
+    assertThat(result).isEqualTo(FailureInternal)
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/fake/FakeAuth.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/fake/FakeAuth.kt
@@ -1,0 +1,82 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.fake
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth.AuthenticationResult.*
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.User
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.AuthBuilder
+import kotlinx.coroutines.flow.*
+
+/**
+ * A fake implementation of [Auth] which keeps all the users in memory, alongside with a record of
+ * all the user accounts present within it.
+ */
+class FakeAuth : Auth, AuthBuilder {
+
+  private val record =
+      MutableStateFlow(FakeAuthRecord(currentUser = null, users = emptySet(), nextUid = 0))
+
+  override val currentUser: Flow<User?>
+    get() = record.map { it.currentUser }.distinctUntilChanged()
+
+  override suspend fun signInWithEmail(
+      email: String,
+      password: String,
+  ): Auth.AuthenticationResult {
+    val users = record.value.users
+    val user = users.firstOrNull { it.email == email } ?: return FailureInternal
+    if (user.password != password) {
+      return FailureInternal
+    }
+    record.update { it.copy(currentUser = user) }
+    return Success(user)
+  }
+
+  override suspend fun signUpWithEmail(
+      email: String,
+      password: String,
+  ): Auth.AuthenticationResult {
+    return addUser(email, password)
+  }
+
+  override suspend fun signOut() {
+    record.update { it.copy(currentUser = null) }
+  }
+
+  override fun user(email: String, password: String) {
+    addUser(email, password)
+  }
+
+  /**
+   * A helper method which automatically adds a new user, if possible, to the [FakeAuth].
+   *
+   * @param email the email address to use.
+   * @param password the password of the added user.
+   *
+   * @return the result of adding the new user.
+   */
+  private fun addUser(
+      email: String,
+      password: String,
+  ): Auth.AuthenticationResult {
+
+    // Compare-and-set to handle concurrent updates.
+    while (true) {
+      val rec = record.value
+      val users = rec.users
+
+      // If an account already exists with this email, we must return an authentication failure.
+      val exists = users.any { it.email == email }
+      if (exists) return FailureInternal
+
+      // Generate a new UID, and create an updated record.
+      val uid = rec.nextUid
+      val newUser = FakeUser(uid = "$uid", email = email, password = password)
+      val newRec = FakeAuthRecord(currentUser = newUser, users = users + newUser, nextUid = uid + 1)
+
+      // Only update if the data is consistent with what we had read. Otherwise, we can safely retry
+      // to perform the whole block atomically. A new UID may be generated, and we'll see newly
+      // added users too.
+      if (record.compareAndSet(rec, newRec)) return Success(newUser)
+    }
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/fake/FakeAuthRecord.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/fake/FakeAuthRecord.kt
@@ -1,0 +1,10 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.fake
+
+/**
+ * A record of the currently connected user, as well as the users which can be used to authenticate.
+ */
+data class FakeAuthRecord(
+    val currentUser: FakeUser?,
+    val users: Set<FakeUser>,
+    val nextUid: Int,
+)

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/fake/FakeUser.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/fake/FakeUser.kt
@@ -1,0 +1,16 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.fake
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.User
+
+/**
+ * An implementation of [User] which is faked and has no behavior.
+ *
+ * @param uid the unique identifier for this [User].
+ * @param email the email address of this [User], if available.
+ * @param password the password which this user authenticates with.
+ */
+data class FakeUser(
+    override val uid: String,
+    override val email: String?,
+    val password: String,
+) : User

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/firestore/FirebaseAuthTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/firestore/FirebaseAuthTest.kt
@@ -1,0 +1,121 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.firestore
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.firebase.FirebaseAuth
+import com.google.android.gms.tasks.Tasks
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.FirebaseAuth as ActualFirebaseAuth
+import com.google.firebase.auth.FirebaseAuth.AuthStateListener
+import com.google.firebase.auth.FirebaseUser
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class FirebaseAuthTest {
+
+  @Test
+  fun currentUser_returnsFirebaseUser() = runTest {
+    val mock = mockk<ActualFirebaseAuth>()
+    val user = mockk<FirebaseUser>()
+    val auth = FirebaseAuth(mock)
+
+    every { user.uid } returns "uid"
+    every { user.email } returns null
+    every { mock.currentUser } returns user
+    every { mock.addAuthStateListener(any()) }.answers {
+      val listener = it.invocation.args[0] as AuthStateListener
+      listener.onAuthStateChanged(mock)
+    }
+    every { mock.removeAuthStateListener(any()) } returns Unit
+
+    val fetched = auth.currentUser.filterNotNull().first()
+    assertThat(fetched.uid).isEqualTo("uid")
+    assertThat(fetched.email).isNull()
+  }
+
+  @Test
+  fun signUpWithEmail_returnsSuccessfully() = runTest {
+    val mock = mockk<ActualFirebaseAuth>()
+    val result = mockk<AuthResult>()
+    val auth = FirebaseAuth(mock)
+
+    every { result.user } returns null
+    every { mock.createUserWithEmailAndPassword(any(), any()) } returns Tasks.forResult(result)
+
+    val user = auth.signUpWithEmail("email", "password")
+
+    assertThat(user).isInstanceOf(Auth.AuthenticationResult::class.java)
+    verify { mock.createUserWithEmailAndPassword("email", "password") }
+  }
+
+  @Test
+  fun signInWithEmail_returnsSuccessfullyWithNullUser() = runTest {
+    val mock = mockk<ActualFirebaseAuth>()
+    val result = mockk<AuthResult>()
+    val auth = FirebaseAuth(mock)
+
+    every { result.user } returns null
+    every { mock.signInWithEmailAndPassword(any(), any()) } returns Tasks.forResult(result)
+
+    val user = auth.signInWithEmail("email", "password")
+
+    assertThat(user).isInstanceOf(Auth.AuthenticationResult::class.java)
+    verify { mock.signInWithEmailAndPassword("email", "password") }
+  }
+
+  @Test
+  fun signInWithEmail_returnsSuccessfullyWithNullAuthResult() = runTest {
+    val mock = mockk<ActualFirebaseAuth>()
+    val auth = FirebaseAuth(mock)
+
+    every { mock.signInWithEmailAndPassword(any(), any()) } returns Tasks.forResult(null)
+
+    val user = auth.signInWithEmail("email", "password")
+
+    assertThat(user).isInstanceOf(Auth.AuthenticationResult::class.java)
+    verify { mock.signInWithEmailAndPassword("email", "password") }
+  }
+
+  @Test
+  fun signInWithEmail_returnsSuccessfullyWithNonNullUser() = runTest {
+    val mock = mockk<ActualFirebaseAuth>()
+    val user = mockk<FirebaseUser>()
+    val result = mockk<AuthResult>()
+    val auth = FirebaseAuth(mock)
+
+    every { result.user } returns user
+    every { mock.signInWithEmailAndPassword(any(), any()) } returns Tasks.forResult(result)
+
+    val fetched = auth.signInWithEmail("email", "password")
+
+    assertThat(fetched).isInstanceOf(Auth.AuthenticationResult::class.java)
+    verify { mock.signInWithEmailAndPassword("email", "password") }
+  }
+
+  @Test
+  fun signOut_actuallySignsOut() = runTest {
+    val mock = mockk<ActualFirebaseAuth>()
+    val auth = FirebaseAuth(mock)
+    every { mock.signOut() } returns Unit
+
+    auth.signOut()
+
+    verify { mock.signOut() }
+  }
+
+  @Test
+  fun signIn_failsOnExceptions() = runTest {
+    val mock = mockk<ActualFirebaseAuth>()
+    val auth = FirebaseAuth(mock)
+    every { mock.signInWithEmailAndPassword(any(), any()) } throws Throwable()
+
+    val result = auth.signInWithEmail("email", "password")
+
+    assertThat(result).isEqualTo(Auth.AuthenticationResult.FailureInternal)
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/CompositionLocalsTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/CompositionLocalsTest.kt
@@ -1,7 +1,7 @@
 package ch.epfl.sdp.mobile.test.state
 
 import androidx.compose.ui.test.junit4.createComposeRule
-import ch.epfl.sdp.mobile.state.LocalAuthenticationApi
+import ch.epfl.sdp.mobile.state.LocalAuthenticationFacade
 import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
@@ -13,7 +13,7 @@ class CompositionLocalsTest {
   @Test
   fun missingAuthenticationApi_throwsException() {
     assertThrows(IllegalStateException::class.java) {
-      rule.setContent { LocalAuthenticationApi.current }
+      rule.setContent { LocalAuthenticationFacade.current }
     }
   }
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/NavigationTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/NavigationTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import ch.epfl.sdp.mobile.state.Navigation
-import ch.epfl.sdp.mobile.state.ProvideApis
+import ch.epfl.sdp.mobile.state.ProvideFacades
 import ch.epfl.sdp.mobile.test.application.AlwaysSucceedingAuthenticationFacade
 import ch.epfl.sdp.mobile.test.application.SuspendingAuthenticationFacade
 import kotlinx.coroutines.test.runTest
@@ -20,7 +20,7 @@ class NavigationTest {
   @Test
   fun loadingSection_isEmpty() {
     rule.setContentWithLocalizedStrings {
-      ProvideApis(SuspendingAuthenticationFacade) { Navigation() }
+      ProvideFacades(SuspendingAuthenticationFacade) { Navigation() }
     }
     rule.onAllNodes(keyIsDefined(SemanticsProperties.Text)).assertCountEquals(0)
   }
@@ -28,7 +28,7 @@ class NavigationTest {
   @Test
   fun notAuthenticated_displaysAuthenticationScreen() = runTest {
     val api = AlwaysSucceedingAuthenticationFacade()
-    val strings = rule.setContentWithLocalizedStrings { ProvideApis(api) { Navigation() } }
+    val strings = rule.setContentWithLocalizedStrings { ProvideFacades(api) { Navigation() } }
 
     // Do we see the authentication screen actions ?
     rule.onNodeWithText(strings.authenticatePerformRegister).assertExists()
@@ -37,7 +37,7 @@ class NavigationTest {
   @Test
   fun authenticated_displaysHome() = runTest {
     val api = AlwaysSucceedingAuthenticationFacade()
-    val strings = rule.setContentWithLocalizedStrings { ProvideApis(api) { Navigation() } }
+    val strings = rule.setContentWithLocalizedStrings { ProvideFacades(api) { Navigation() } }
     api.signUpWithEmail("email", "name", "password")
 
     // Do we see the bottom navigation ?

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/auth/Auth.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/auth/Auth.kt
@@ -1,0 +1,57 @@
+package ch.epfl.sdp.mobile.infrastructure.persistence.auth
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * An interface representing the primitives that the application may used to perform some basic
+ * authentication duties.
+ */
+interface Auth {
+
+  /** An enumeration which represents the result of an authentication operation. */
+  sealed interface AuthenticationResult {
+
+    /**
+     * Indicates that there was a success during authentication.
+     *
+     * @param user the [User] that is currently set.
+     */
+    data class Success(val user: User?) : AuthenticationResult
+
+    /** Indicates that there was a failure during authentication. */
+    object FailureInternal : AuthenticationResult
+
+    // TODO : Some specific failures could be added here, like FailureBadPassword, etc.
+  }
+
+  /**
+   * Returns a [Flow] of the currently logged-in user. If no user is currently logged in, the [Flow]
+   * will return some null values.
+   */
+  val currentUser: Flow<User?>
+
+  /**
+   * Attempts to sign in with the provided email and password.
+   *
+   * @param email the email to use for authentication.
+   * @param password the password to use for authentication.
+   */
+  suspend fun signInWithEmail(
+      email: String,
+      password: String,
+  ): AuthenticationResult
+
+  /**
+   * Attempts to sign up and create an account with the provided email and password.
+   *
+   * @param email the email to use for authentication.
+   * @param password the password to use for authentication.
+   */
+  suspend fun signUpWithEmail(
+      email: String,
+      password: String,
+  ): AuthenticationResult
+
+  /** Signs the current user out. If no user was currently connected, this will no-op. */
+  suspend fun signOut()
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/auth/User.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/auth/User.kt
@@ -1,0 +1,14 @@
+package ch.epfl.sdp.mobile.infrastructure.persistence.auth
+
+/**
+ * An interface representing a [User], which may be used to perform some basic authentication
+ * queries.
+ */
+interface User {
+
+  /** The unique identifier for this [User]. */
+  val uid: String
+
+  /** The email address for this user, if the user performed authentication with their email. */
+  val email: String?
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/auth/firebase/FirebaseAuth.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/auth/firebase/FirebaseAuth.kt
@@ -1,0 +1,67 @@
+package ch.epfl.sdp.mobile.infrastructure.persistence.auth.firebase
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.Auth.AuthenticationResult
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.User
+import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.FirebaseAuth as ActualFirebaseAuth
+import com.google.firebase.auth.FirebaseAuth.AuthStateListener
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.tasks.await
+
+/**
+ * An implementation of the [Auth] API which encapsulates an [ActualFirebaseAuth] and adapts it.
+ *
+ * @param actual the [ActualFirebaseAuth].
+ */
+class FirebaseAuth(private val actual: ActualFirebaseAuth) : Auth {
+
+  override val currentUser: Flow<User?>
+    get() =
+        callbackFlow {
+          val listener = AuthStateListener { auth -> trySend(auth.currentUser) }
+          actual.addAuthStateListener(listener)
+          awaitClose { actual.removeAuthStateListener(listener) }
+        }
+            .buffer(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+            .map { it?.let(::FirebaseUser) }
+
+  /**
+   * Runs the [block] and maps the resulting [AuthResult] to an [AuthenticationResult].
+   *
+   * @param block the block of code which is used to interact with Firebase.
+   */
+  private suspend fun authenticate(
+      block: suspend () -> AuthResult?,
+  ): AuthenticationResult =
+      try {
+        val result = block()
+        val user = result?.user?.let(::FirebaseUser)
+        AuthenticationResult.Success(user)
+      } catch (other: Throwable) {
+        AuthenticationResult.FailureInternal
+      }
+
+  override suspend fun signInWithEmail(
+      email: String,
+      password: String,
+  ): AuthenticationResult = authenticate {
+    actual.signInWithEmailAndPassword(email, password).await()
+  }
+
+  override suspend fun signUpWithEmail(
+      email: String,
+      password: String,
+  ): AuthenticationResult = authenticate {
+    actual.createUserWithEmailAndPassword(email, password).await()
+  }
+
+  override suspend fun signOut() {
+    actual.signOut()
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/auth/firebase/FirebaseUser.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/auth/firebase/FirebaseUser.kt
@@ -1,0 +1,18 @@
+package ch.epfl.sdp.mobile.infrastructure.persistence.auth.firebase
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.auth.User
+import com.google.firebase.auth.FirebaseUser as ActualFirebaseUser
+
+/**
+ * An implementation of [User] which makes use of the [ActualFirebaseUser] API and adapts it.
+ *
+ * @param actual the [ActualFirebaseUser].
+ */
+class FirebaseUser(private val actual: ActualFirebaseUser) : User {
+
+  override val uid: String
+    get() = actual.uid
+
+  override val email: String?
+    get() = actual.email
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/CompositionLocals.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/CompositionLocals.kt
@@ -6,20 +6,20 @@ import androidx.compose.runtime.compositionLocalOf
 import ch.epfl.sdp.mobile.application.AuthenticationFacade
 
 /** A global composition local which provides access to an instance of [AuthenticationFacade]. */
-val LocalAuthenticationApi = compositionLocalOf<AuthenticationFacade> { error("Missing API.") }
+val LocalAuthenticationFacade = compositionLocalOf<AuthenticationFacade> { error("Missing API.") }
 
 /**
- * Provides the given APIs through different [androidx.compose.runtime.CompositionLocal] values
+ * Provides the given Faces through different [androidx.compose.runtime.CompositionLocal] values
  * available throughout the hierarchy.
  *
  * @param authentication the [AuthenticationFacade] that will be provided.
  */
 @Composable
-fun ProvideApis(
+fun ProvideFacades(
     authentication: AuthenticationFacade,
     content: @Composable () -> Unit,
 ) {
   CompositionLocalProvider(
-      LocalAuthenticationApi provides authentication,
+      LocalAuthenticationFacade provides authentication,
   ) { content() }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/HomeActivity.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/HomeActivity.kt
@@ -22,7 +22,7 @@ class HomeActivity : ComponentActivity() {
     setContent {
       PawniesTheme {
         ProvideLocalizedStrings {
-          ProvideApis(
+          ProvideFacades(
               authentication = authentication,
           ) { Navigation() }
         }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/Navigation.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/Navigation.kt
@@ -42,7 +42,7 @@ private sealed interface UserState {
 /** Returns the current [UserState] in the composition. */
 @Composable
 private fun rememberUserState(): State<UserState> {
-  val auth = LocalAuthenticationApi.current
+  val auth = LocalAuthenticationFacade.current
   return remember(auth) { auth.currentUser.map { it.toUserState() } }
       .collectAsState(UserState.Loading)
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulAuthenticationScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulAuthenticationScreen.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 fun StatefulAuthenticationScreen(
     modifier: Modifier = Modifier,
 ) {
-  val authentication = LocalAuthenticationApi.current
+  val authentication = LocalAuthenticationFacade.current
   val strings = LocalLocalizedStrings.current
   val scope = rememberCoroutineScope()
   val state =


### PR DESCRIPTION
This PR adds some `Auth` and `User` interfaces, which can be used to mock Firebase authentication. Additionally, some fake in-memory implementations are provided, alongside with a simple DSL to build an `Auth` instance with some users.

Some additional work is still require to migrate the `AuthenticationFacade` interface to use this `Auth` interface, and will come in some follow-up PRs.

---

## DSL Example

```kotlin
val auth = buildAuth {
  user("alexandre.piveteau@epfl.ch", "password")
  user("john.cena@epfl.ch", "HELLO")
}

val result = auth.signInWithEmail("alexandre.piveteau@epfl.ch", "password") // Success
```