### PR TITLE
Implement an immutable chess engine

### DIFF
--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/Position.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/Position.kt
@@ -1,0 +1,43 @@
+package ch.epfl.sdp.mobile.application.chess
+
+/**
+ * A class representing some valid coordinates on a board. Coordinates start at the top-left corner
+ * of the board, and the x axis increases towards the right while the y axis increases towards the
+ * bottom.
+ *
+ * @param x the coordinate on the first axis.
+ * @param y the coordinate on the second axis.
+ */
+data class Position(val x: Int, val y: Int) {
+
+  /** Returns true iff the [x] and the [y] coordinates are both the board bounds. */
+  private val inBounds: Boolean = x in AxisBounds && y in AxisBounds
+
+  /** Adds a [Delta] to the [Position], and returns it only if the result is in bounds. */
+  operator fun plus(delta: Delta): Position? {
+    return Position(x + delta.x, y + delta.y).takeIf { inBounds }
+  }
+
+  companion object {
+
+    /** The bounds which correspond to the valid positions on a board. */
+    private val AxisBounds = 0..7
+
+    /** Returns a [Sequence] with all the valid [Position] within a board. */
+    fun all(): Sequence<Position> = sequence {
+      for (i in AxisBounds) {
+        for (j in AxisBounds) {
+          yield(Position(i, j))
+        }
+      }
+    }
+  }
+}
+
+/**
+ * A class representing the difference between two [Position].
+ *
+ * @param x the delta on the first axis.
+ * @param y the delta on the second axis.
+ */
+data class Delta(val x: Int, val y: Int)


### PR DESCRIPTION
This PR will eventually introduce a chess engine, following a few principles :

- The board and engine will be immutable, and maybe rely on [persistent collections](https://en.wikipedia.org/wiki/Persistent_data_structure).
- A board will not let users perform moves when the game is lost, or in a draw.

The immutability of the board and engine ensures that it interacts smoothly with Compose and that a game state can easily be persisted in the `Store` layer.