### PR TITLE
Fix `FirestoreDocumentReference.update()`

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreDocumentReferenceTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreDocumentReferenceTest.kt
@@ -91,11 +91,11 @@ class FirestoreDocumentReferenceTest {
     val doc = mockk<DocumentReference>()
     val reference = FirestoreDocumentReference(doc)
 
-    every { doc.set(any(), SetOptions.merge()) } returns Tasks.forResult(null)
+    every { doc.set(mapOf("key" to "value"), SetOptions.merge()) } returns Tasks.forResult(null)
 
     reference.update { this["key"] = "value" }
 
-    verify { doc.set(any(), SetOptions.merge()) }
+    verify { doc.set(mapOf("key" to "value"), SetOptions.merge()) }
   }
   @Test
   fun set_callsApiWithRightArguments() = runTest {

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreDocumentReference.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreDocumentReference.kt
@@ -43,7 +43,7 @@ class FirestoreDocumentReference(
   }
 
   override suspend fun update(scope: DocumentEditScope.() -> Unit) {
-    val values = FirestoreDocumentEditScope().apply(scope)
+    val values = FirestoreDocumentEditScope().apply(scope).values
     reference.set(values, SetOptions.merge()).await()
   }
 


### PR DESCRIPTION
The object passed to the Firestore API was the `DocumentEditScope` rather than the values to set to the document. This was passing the mocking tests because the actual mocked value was not checked.

The test has been updated to reproduce the issue by specifying the values which are expected to be passed to the Firestore library.