### PR TITLE
Add support for atomic union and remove in array fields

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentRecord.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentRecord.kt
@@ -21,7 +21,9 @@ data class FakeDocumentRecord(val fields: Map<String, Any?>) {
    */
   fun update(scope: DocumentEditScope.() -> Unit): FakeDocumentRecord {
     val recorded = RecordingDocumentEditScope().apply(scope)
-    return copy(fields = fields + recorded.mutations)
+    val mutations = recorded.mutations.map { (f, v) -> FakeFieldMutation.from(f, v) }
+    val updated = mutations.fold(fields) { acc, m -> acc + (m.field to m.mutate(acc[m.field])) }
+    return copy(fields = updated)
   }
 
   companion object

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeFieldMutation.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeFieldMutation.kt
@@ -1,0 +1,53 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.FieldValue
+
+/**
+ * An interface representing the different kinds of mutations which may be applied to a field.
+ *
+ * @param field the name of the field to which the mutation is applied.
+ */
+sealed class FakeFieldMutation(val field: String) {
+
+  /**
+   * Mutates the existing value and transforms it through this mutation.
+   *
+   * @param value the existing value.
+   * @return the mutated result.
+   */
+  abstract fun mutate(value: Any?): Any?
+
+  companion object Factory {
+
+    /**
+     * Creates a [FakeFieldMutation] for the given [field] and the provided [value].
+     *
+     * @param field the field for which we're creating the mutation.
+     * @param value the value which was set.
+     */
+    fun from(field: String, value: Any?): FakeFieldMutation =
+        when (value) {
+          is FieldValue.ArrayUnion -> ArrayUnion(field, value.values)
+          is FieldValue.ArrayRemove -> ArrayRemove(field, value.values)
+          else -> Set(field, value)
+        }
+  }
+}
+
+private class Set(field: String, private val to: Any?) : FakeFieldMutation(field) {
+  override fun mutate(value: Any?): Any? = to
+}
+
+private class ArrayUnion(field: String, private val values: List<Any>) : FakeFieldMutation(field) {
+  override fun mutate(value: Any?): Any {
+    val existing = value as? List<Any?> ?: emptyList()
+    return existing + values.minus(existing)
+  }
+}
+
+private class ArrayRemove(field: String, private val values: List<Any>) : FakeFieldMutation(field) {
+  override fun mutate(value: Any?): Any {
+    val existing = value as? List<Any?> ?: emptyList()
+    return existing.minus(values)
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FieldValueTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FieldValueTest.kt
@@ -1,0 +1,110 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.arrayRemove
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.arrayUnion
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.asFlow
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.set
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.emptyStore
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class FieldValueTest {
+
+  data class DocWithoutArray(
+      val value: Any? = null,
+  )
+
+  data class DocWithArray(
+      val value: List<Any>? = null,
+  )
+
+  @Test
+  fun emptyDocument_union_returnsElements() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").update { arrayUnion("value", "hello", "world") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(listOf("hello", "world")))
+  }
+
+  @Test
+  fun documentWithField_union_overwritesField() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").set(DocWithoutArray("hello"))
+    store.collection("docs").document("abc").update { arrayUnion("value", "hello", "world") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(listOf("hello", "world")))
+  }
+
+  @Test
+  fun documentWithArrayField_union_mergesElements() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").set(DocWithArray(listOf("a")))
+    store.collection("docs").document("abc").update { arrayUnion("value", "b", "c") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(listOf("a", "b", "c")))
+  }
+
+  @Test
+  fun documentWithArrayField_union_ignoresDuplicates() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").set(DocWithArray(listOf("a")))
+    store.collection("docs").document("abc").update { arrayUnion("value", "b", "a") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(listOf("a", "b")))
+  }
+
+  @Test
+  fun emptyDocument_remove_returnsEmptyArray() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").update { arrayRemove("value") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(emptyList()))
+  }
+
+  @Test
+  fun documentWithField_remove_overwritesField() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").set(DocWithoutArray("hello"))
+    store.collection("docs").document("abc").update { arrayRemove("value", "test") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(emptyList()))
+  }
+
+  @Test
+  fun documentWithArrayField_remove_deletesElements() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").set(DocWithArray(listOf("a", "b", "c")))
+    store.collection("docs").document("abc").update { arrayRemove("value", "a", "c") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(listOf("b")))
+  }
+
+  @Test
+  fun documentWithArrayField_remove_ignoresUnknown() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").set(DocWithArray(listOf("a", "b", "c")))
+    store.collection("docs").document("abc").update { arrayRemove("value", "d") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(listOf("a", "b", "c")))
+  }
+
+  @Test
+  fun documentWithArrayField_remove_handlesDuplicates() = runTest {
+    val store = emptyStore()
+    store.collection("docs").document("abc").set(DocWithArray(listOf("a", "a")))
+    store.collection("docs").document("abc").update { arrayRemove("value", "a") }
+
+    val doc = store.collection("docs").document("abc").asFlow<DocWithArray>().first()
+    assertThat(doc).isEqualTo(DocWithArray(emptyList()))
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreFieldValueTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreFieldValueTest.kt
@@ -1,0 +1,60 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.firestore
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.arrayRemove
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.arrayUnion
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.firestore.FirestoreDocumentReference
+import com.google.android.gms.tasks.Tasks
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.SetOptions
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class FirestoreFieldValueTest {
+
+  @Test
+  fun updateWithArrayUnion_callsApiWithRightArguments() = runTest {
+    val doc = mockk<DocumentReference>()
+    val reference = FirestoreDocumentReference(doc)
+
+    every { doc.set(any(), SetOptions.merge()) } answers
+        {
+          // Because FieldValue.equals() is not properly defined, we can't really check for
+          // equality, but we can check that it extends Firestore's FieldValue (and that the
+          // translation was successful.
+          val arg = firstArg<Map<String, FieldValue>>()
+          assertThat(arg).isNotEmpty()
+          assertThat(arg["key"]).isInstanceOf(FieldValue::class.java)
+          Tasks.forResult(null)
+        }
+
+    reference.update { arrayUnion("key", "value") }
+
+    verify { doc.set(any(), SetOptions.merge()) }
+  }
+
+  @Test
+  fun updateWithArrayRemove_callsApiWithRightArguments() = runTest {
+    val doc = mockk<DocumentReference>()
+    val reference = FirestoreDocumentReference(doc)
+
+    every { doc.set(any(), SetOptions.merge()) } answers
+        {
+          // Because FieldValue.equals() is not properly defined, we can't really check for
+          // equality, but we can check that it extends Firestore's FieldValue (and that the
+          // translation was successful.
+          val arg = firstArg<Map<String, FieldValue>>()
+          assertThat(arg).isNotEmpty()
+          assertThat(arg["key"]).isInstanceOf(FieldValue::class.java)
+          Tasks.forResult(null)
+        }
+
+    reference.update { arrayRemove("key", "value") }
+
+    verify { doc.set(any(), SetOptions.merge()) }
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/DocumentEditScope.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/DocumentEditScope.kt
@@ -11,3 +11,29 @@ interface DocumentEditScope {
    */
   operator fun set(field: String, value: Any?)
 }
+
+/**
+ * A variation of [set] which performs the union of the values of an array with key [field] and the
+ * provided [values]. If the field being modified is not already an array, an array with the
+ * specified elements will be created.
+ *
+ * @param field the field to edit.
+ * @param values the values to add to the array at this field.
+ */
+fun DocumentEditScope.arrayUnion(
+    field: String,
+    vararg values: Any,
+): Unit = set(field, FieldValue.ArrayUnion(values.toList()))
+
+/**
+ * A variation of [set] which performs a subtraction of the values of an array with the key [field]
+ * and the provided [values]. If the field being modified is not already an array, an empty array
+ * will be created.
+ *
+ * @param field the field to edit.
+ * @param values the values to remove from the array at this field.
+ */
+fun DocumentEditScope.arrayRemove(
+    field: String,
+    vararg values: Any,
+): Unit = set(field, FieldValue.ArrayRemove(values.toList()))

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/FieldValue.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/FieldValue.kt
@@ -1,0 +1,22 @@
+package ch.epfl.sdp.mobile.infrastructure.persistence.store
+
+/**
+ * An interface defining some sentinel values which may be used within [DocumentEditScope] to
+ * perform some special operations on fields.
+ */
+sealed interface FieldValue {
+
+  /**
+   * A sentinel value which performs array union on a field.
+   *
+   * @param values the values which are added to the array.
+   */
+  data class ArrayUnion(val values: List<Any>) : FieldValue
+
+  /**
+   * A sentinel value which performs array removal on a field.
+   *
+   * @param values the values which are removed from the array.
+   */
+  data class ArrayRemove(val values: List<Any>) : FieldValue
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreDocumentEditScope.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreDocumentEditScope.kt
@@ -1,6 +1,9 @@
 package ch.epfl.sdp.mobile.infrastructure.persistence.store.firestore
 
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentEditScope
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.FieldValue
+import com.google.firebase.firestore.FieldValue.arrayRemove
+import com.google.firebase.firestore.FieldValue.arrayUnion
 
 /**
  * An implementation of [DocumentEditScope] which keeps track of all the updates to apply to a
@@ -14,6 +17,20 @@ class FirestoreDocumentEditScope : DocumentEditScope {
   val values: Map<String, Any?> = fields
 
   override fun set(field: String, value: Any?) {
-    fields[field] = value
+    fields[field] = value.mapFirestoreFieldValue()
   }
 }
+
+/**
+ * Maps an optional [Any] which may be a [FieldValue] to a native Firestore
+ * [com.google.firebase.firestore.FieldValue] if it corresponds.
+ *
+ * @receiver an optional [Any] for which we want to map field values.
+ * @return the mapped [Any] if it was a [FieldValue].
+ */
+private fun Any?.mapFirestoreFieldValue(): Any? =
+    when (this) {
+      is FieldValue.ArrayUnion -> arrayUnion(*values.toTypedArray())
+      is FieldValue.ArrayRemove -> arrayRemove(*values.toTypedArray())
+      else -> this
+    }


### PR DESCRIPTION
A `FieldValue` sealed interface is added to the `Store` API, as well as some extensions to `DocumentEditScope` which provide behaviours for array union and remove.