### PR TITLE
Add `PieceIdentifier` to pieces

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/chess/GameTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/chess/GameTest.kt
@@ -36,7 +36,17 @@ class GameTest {
     val game = emptyGame()
     val black = game.board[Position(4, 0)]
     val white = game.board[Position(4, 7)]
-    assertThat(black).isEqualTo(Piece(Color.Black, Rank.King))
-    assertThat(white).isEqualTo(Piece(Color.White, Rank.King))
+    assertThat(black?.color).isEqualTo(Color.Black)
+    assertThat(black?.rank).isEqualTo(Rank.King)
+    assertThat(white?.color).isEqualTo(Color.White)
+    assertThat(white?.rank).isEqualTo(Rank.King)
+  }
+
+  @Test
+  fun emptyGame_twoPawnsAreDifferent() {
+    val game = emptyGame()
+    val a = game.board[Position(0, 1)]
+    val b = game.board[Position(1, 1)]
+    assertThat(a).isNotEqualTo(b)
   }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/Piece.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/Piece.kt
@@ -3,7 +3,12 @@ package ch.epfl.sdp.mobile.application.chess
 /**
  * A class representing a chess piece, with its color and rank.
  *
+ * When checking for equality, pieces should first check for their [color] and [rank], and if they
+ * are equal, the [id] should be compared as well. A [Board] may contain some pieces with the same
+ * [id] but different colors and ranks, but each triplet ([Color], [Rank], [id]) will be unique.
+ *
  * @param color the [Color] of the player who owns the piece.
  * @param rank the rank indicating the abilities of the [Piece].
+ * @param id the unique identifier for this piece, used for disambiguation.
  */
-data class Piece(val color: Color, val rank: Rank)
+data class Piece(val color: Color, val rank: Rank, val id: PieceIdentifier)

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/PieceIdentifier.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/PieceIdentifier.kt
@@ -1,0 +1,8 @@
+package ch.epfl.sdp.mobile.application.chess
+
+/**
+ * A way for pieces to be uniquely identified. This will let the rendering system smoothly animate
+ * between board positions, since pieces with the same stable ids can have their positions
+ * interpolated.
+ */
+interface PieceIdentifier

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/internal/PersistentBoard.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/internal/PersistentBoard.kt
@@ -5,21 +5,25 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 
+/** Transforms the given [Int] to a [PersistentPieceIdentifier]. */
+private fun Int.toId(): PieceIdentifier = PersistentPieceIdentifier(this)
+
 /** Returns a row with all the pieces of the given color. */
 private fun piecesRow(color: Color) =
     persistentListOf(
-        Piece(color, Rank.Rook),
-        Piece(color, Rank.Knight),
-        Piece(color, Rank.Bishop),
-        Piece(color, Rank.Queen),
-        Piece(color, Rank.King),
-        Piece(color, Rank.Bishop),
-        Piece(color, Rank.Knight),
-        Piece(color, Rank.Rook),
+        Piece(color, Rank.Rook, 0.toId()),
+        Piece(color, Rank.Knight, 0.toId()),
+        Piece(color, Rank.Bishop, 0.toId()),
+        Piece(color, Rank.Queen, 0.toId()),
+        Piece(color, Rank.King, 0.toId()),
+        Piece(color, Rank.Bishop, 1.toId()),
+        Piece(color, Rank.Knight, 1.toId()),
+        Piece(color, Rank.Rook, 1.toId()),
     )
 
 /** Returns a row with only pawns of the given color. */
-private fun pawnsRow(color: Color) = List(8) { Piece(color, Rank.Pawn) }.toPersistentList()
+private fun pawnsRow(color: Color) =
+    List(8) { Piece(color, Rank.Pawn, it.toId()) }.toPersistentList()
 
 /** Returns a row with */
 private val EmptyRow = List(8) { null }.toPersistentList()

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/internal/PersistentPieceIdentifier.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/internal/PersistentPieceIdentifier.kt
@@ -1,0 +1,11 @@
+package ch.epfl.sdp.mobile.application.chess.internal
+
+import ch.epfl.sdp.mobile.application.chess.PieceIdentifier
+
+/**
+ * An implementation of [PieceIdentifier] which simply contains an internal unique identifier, and
+ * is stable.
+ *
+ * @param id the actual identifier of the piece.
+ */
+data class PersistentPieceIdentifier(private val id: Int) : PieceIdentifier


### PR DESCRIPTION
This PR introduces `PieceIdentifier` to `Piece`, which acts as a disambiguator when two pieces share the same color and rank. A disambiguator is necessary to implement smooth UI transitions between different board states, to keep track of how each piece should animate within a move.

While I'm not fully convinced by the API design for the identifiers right now (especially because they seem like they're an abstraction leak of how `Piece` is defined), it's probably better to ship them as-is for now, so @matt989253 can use it when implementing the `Board` composable.