### PR TITLE
Fix profile update deleting all existing fields

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/AuthenticationFacadeTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/AuthenticationFacadeTest.kt
@@ -113,6 +113,22 @@ class AuthenticationFacadeTest {
   }
 
   @Test
+  fun authenticatedUserPartialUpdate_preservesExistingFields() = runTest {
+    val auth = emptyAuth()
+    val store = emptyStore()
+    val facade = AuthenticationFacade(auth, store)
+
+    facade.signUpWithEmail("email@email.com", "Alexandre", "password")
+
+    val userAuthenticated = facade.currentUser.filterIsInstance<AuthenticatedUser>().first()
+
+    userAuthenticated.update { emoji("🇺🇦") }
+
+    val updatedUser = facade.currentUser.filterIsInstance<AuthenticatedUser>().first()
+    assertThat(updatedUser.name).isEqualTo("Alexandre")
+  }
+
+  @Test
   fun gettingProfileWithNullValuesAssignsDefaultValues() = runTest {
     val auth = buildAuth { user("email@example.org", "password") }
     val store = buildStore { collection("users") { document("uid", ProfileDocument()) } }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/authentication/AuthenticatedUser.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/authentication/AuthenticatedUser.kt
@@ -47,7 +47,7 @@ class AuthenticatedUser(
    */
   suspend fun update(block: UpdateScope.() -> Unit): Boolean {
     return try {
-      firestore.collection("users").document(user.uid).set { UpdateScope(this).also(block) }
+      firestore.collection("users").document(user.uid).update { UpdateScope(this).also(block) }
       true
     } catch (exception: Throwable) {
       false


### PR DESCRIPTION
When a profile was updated, all the fields (including the future list of following users !) were cleared. This PR includes a reproducer test as well the fix.