### PR TITLE
Ensure that `FakeStore.collection` returns an empty query snapshot

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/Coroutines.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/Coroutines.kt
@@ -1,6 +1,26 @@
 package ch.epfl.sdp.mobile.test
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 /** Returns any value by suspending forever. */
 suspend inline fun suspendForever(): Nothing = suspendCancellableCoroutine {}
+
+/**
+ * Combines the [Collection] of [Flow] using the standard [combine] operator, using an empty list if
+ * the collection of flows is empty.
+ *
+ * (see https://github.com/Kotlin/kotlinx.coroutines/issues/1603 for more information about why this
+ * is not the default behavior for [combine]).
+ *
+ * @param T the type of the flow items.
+ *
+ * @receiver the [Collection] of [Flow] which is combined.
+ * @return a [Flow] of [R], transformed using the function.
+ */
+inline fun <reified T> Collection<Flow<T>>.combineOrEmpty(): Flow<List<T>> {
+  if (isEmpty()) return flowOf(emptyList())
+  return combine(this) { it.toList() }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/DslTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/DslTest.kt
@@ -3,8 +3,6 @@ package ch.epfl.sdp.mobile.test.infrastructure.persistence.store
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.asFlow
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.set
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Test

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/DslTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/DslTest.kt
@@ -3,6 +3,8 @@ package ch.epfl.sdp.mobile.test.infrastructure.persistence.store
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.asFlow
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.set
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -23,6 +25,13 @@ class DslTest {
     val store = emptyStore()
     val value = store.collection("collection").document("document").asFlow<User>().first()
     assertThat(value).isNull()
+  }
+
+  @Test
+  fun missingDocument_isEmptyList() = runTest {
+    val store = emptyStore()
+    val value = store.collection("col").asFlow<User>().first()
+    assertThat(value).isEmpty()
   }
 
   @Test

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeCollectionReference.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeCollectionReference.kt
@@ -2,13 +2,14 @@ package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake
 
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.CollectionReference
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentReference
+import ch.epfl.sdp.mobile.test.combineOrEmpty
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.CollectionBuilder
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.DocumentBuilder
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.query.FakeQuery
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.serialization.fromObject
 import kotlin.reflect.KClass
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 
 class FakeCollectionReference : CollectionReference, DocumentBuilder, FakeQuery {
@@ -21,7 +22,7 @@ class FakeCollectionReference : CollectionReference, DocumentBuilder, FakeQuery 
 
   override fun asQuerySnapshotFlow(): Flow<FakeQuerySnapshot> {
     val flows = documents.values.map { it.asDocumentSnapshotFlow() }
-    return combine(flows) { FakeQuerySnapshot(it.filterNotNull()) }
+    return flows.combineOrEmpty().map { FakeQuerySnapshot(it.filterNotNull()) }
   }
 
   override fun <T : Any> document(


### PR DESCRIPTION
This PR fixes a bug found by @barmettlerl when implementing the social facade. When an empty collection of a fake facade is queried, if no documents exist, no query snapshot were emitted.

A reproducer is included in the PR.