### PR TITLE
Center the email and name properly in the profile section

### DIFF
--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileScreen.kt
@@ -109,7 +109,7 @@ fun ProfileHeader(state: ProfileScreenState, modifier: Modifier = Modifier) {
       verticalArrangement = Arrangement.spacedBy(16.dp),
   ) {
     ProfilePicture(state)
-    Column {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
       Text(state.name, style = MaterialTheme.typography.h5)
       Text(state.email, style = MaterialTheme.typography.subtitle2)
     }


### PR DESCRIPTION
As noted by @KurohanaJuri, the email isn't properly centred in the profile screen. This PR fixes that issue by specifying the right column alignment.