### PR TITLE
Refactor the chess board

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
@@ -81,6 +81,20 @@ class ChessBoardTest {
   }
 
   @Test
+  fun draggingPawnOutsideBoard_works() = runTest {
+    val state = SinglePieceSnapshotChessBoardState()
+    rule.setContentWithLocalizedStrings {
+      ChessBoard(state, Modifier.size(160.dp).testTag("board"))
+    }
+    rule.onNodeWithTag("board").performTouchInput {
+      down(Offset(10.dp.toPx(), 10.dp.toPx()))
+      moveBy(Offset(-20.dp.toPx(), -20.dp.toPx()))
+      up()
+    }
+    assertThat(state.position).isEqualTo(Position(-1, -1))
+  }
+
+  @Test
   fun draggingPawnAround_withDisabledBoard_movesNothing() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
     val strings =

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
@@ -146,4 +146,30 @@ class ChessBoardTest {
             .getBoundsInRoot()
     assertThat(DpOffset(10.dp, 10.dp) in bounds).isTrue()
   }
+
+  @Test
+  fun disablingBoardDuringDrag_dropsPiece() = runTest {
+    val state = SinglePieceSnapshotChessBoardState()
+    var enabled by mutableStateOf(true)
+    val strings =
+        rule.setContentWithLocalizedStrings {
+          ChessBoard(state, Modifier.size(160.dp).testTag("board"), enabled = enabled)
+        }
+    rule.onNodeWithTag("board").performTouchInput {
+      down(Offset(10.dp.toPx(), 10.dp.toPx()))
+      moveBy(Offset(0.dp.toPx(), 20.dp.toPx()))
+    }
+    enabled = false // We expect the piece to be dropped mid-gesture.
+    rule.onNodeWithTag("board").performTouchInput {
+      moveBy(Offset(0.dp.toPx(), 20.dp.toPx()))
+      up()
+    }
+    val bounds =
+        rule.onNodeWithContentDescription(
+                strings.boardPieceContentDescription(
+                    strings.boardColorWhite, strings.boardPiecePawn),
+            )
+            .getBoundsInRoot()
+    assertThat(DpOffset(10.dp, 30.dp) in bounds).isTrue()
+  }
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
@@ -81,6 +81,27 @@ class ChessBoardTest {
   }
 
   @Test
+  fun draggingPawnAround_withDisabledBoard_movesNothing() = runTest {
+    val state = SinglePieceSnapshotChessBoardState()
+    val strings =
+        rule.setContentWithLocalizedStrings {
+          ChessBoard(state, Modifier.size(160.dp).testTag("board"), enabled = false)
+        }
+    rule.onNodeWithTag("board").performTouchInput {
+      down(Offset(10.dp.toPx(), 10.dp.toPx()))
+      moveBy(Offset(0.dp.toPx(), 40.dp.toPx()))
+      up()
+    }
+    val bounds =
+        rule.onNodeWithContentDescription(
+                strings.boardPieceContentDescription(
+                    strings.boardColorWhite, strings.boardPiecePawn),
+            )
+            .getBoundsInRoot()
+    assertThat(DpOffset(10.dp, 10.dp) in bounds).isTrue()
+  }
+
+  @Test
   fun draggingPawnAround_whileBoardIsSuccessful_dropsOnRightTarget() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
     val strings =

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
@@ -102,7 +102,7 @@ class ChessBoardTest {
   }
 
   @Test
-  fun draggingPawnAround_whileBoardIsSuccessful_dropsOnRightTarget() = runTest {
+  fun draggingPawnAround_whileBoardIsEnabled_dropsOnRightTarget() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
     val strings =
         rule.setContentWithLocalizedStrings {

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoard.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoard.kt
@@ -3,26 +3,26 @@ package ch.epfl.sdp.mobile.ui.game
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.consumeAllChanges
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.min
 import ch.epfl.sdp.mobile.state.LocalLocalizedStrings
-import ch.epfl.sdp.mobile.ui.*
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Color.Black
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Color.White
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Piece
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Position
-import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Rank.*
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 
@@ -151,56 +151,20 @@ private fun Piece(
     piece: Piece,
     modifier: Modifier = Modifier,
 ) {
+  val strings = LocalLocalizedStrings.current
+  val painter =
+      when (piece.color) {
+        Black -> piece.rank.blackIcon
+        White -> piece.rank.whiteIcon
+      }
+  val contentDescription =
+      strings.boardPieceContentDescription(
+          piece.color.contentDescription(strings),
+          piece.rank.contentDescription(strings),
+      )
   Icon(
-      painter = piece.icon,
-      contentDescription = piece.contentDescription,
+      painter = painter(),
+      contentDescription = contentDescription,
       modifier = modifier,
   )
 }
-
-/** Returns the [Painter] associated to the value of this [Piece]. */
-private val Piece.icon: Painter
-  @Composable
-  get() =
-      when (color) {
-        Black ->
-            when (rank) {
-              King -> ChessIcons.BlackKing
-              Queen -> ChessIcons.BlackQueen
-              Rook -> ChessIcons.BlackRook
-              Bishop -> ChessIcons.BlackBishop
-              Knight -> ChessIcons.BlackKnight
-              Pawn -> ChessIcons.BlackPawn
-            }
-        White ->
-            when (rank) {
-              King -> ChessIcons.WhiteKing
-              Queen -> ChessIcons.WhiteQueen
-              Rook -> ChessIcons.WhiteRook
-              Bishop -> ChessIcons.WhiteBishop
-              Knight -> ChessIcons.WhiteKnight
-              Pawn -> ChessIcons.WhitePawn
-            }
-      }
-
-/** Returns the [String] content description associated to the value of this [Piece]. */
-private val Piece.contentDescription: String
-  @Composable
-  get() {
-    val strings = LocalLocalizedStrings.current
-    val color =
-        when (color) {
-          Black -> strings.boardColorBlack
-          White -> strings.boardColorWhite
-        }
-    val rank =
-        when (rank) {
-          King -> strings.boardPieceKing
-          Queen -> strings.boardPieceQueen
-          Rook -> strings.boardPieceRook
-          Bishop -> strings.boardPieceBishop
-          Knight -> strings.boardPieceKnight
-          Pawn -> strings.boardPiecePawn
-        }
-    return strings.boardPieceContentDescription(color, rank)
-  }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoard.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoard.kt
@@ -37,11 +37,13 @@ const val ChessBoardCells = 8
  * @param Piece the type of the pieces.
  * @param state the [ChessBoardState] that is used by this composable.
  * @param modifier the [Modifier] for this composable.
+ * @param enabled true iff the [ChessBoardState] should allow for user interactions.
  */
 @Composable
 fun <Piece : ChessBoardState.Piece> ChessBoard(
     state: ChessBoardState<Piece>,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
   BoxWithConstraints(
       modifier
@@ -94,12 +96,17 @@ fun <Piece : ChessBoardState.Piece> ChessBoard(
                         )
                       }
                     }
-                    .movablePiece(draggingState, currentTarget, cellPx) { droppedPosition ->
-                      scope.launch {
-                        currentTargetAnimatable.snapTo(draggingState.offset)
-                        state.onDropPiece(piece, droppedPosition)
-                      }
-                    }
+                    .then(
+                        if (enabled)
+                            Modifier.movablePiece(draggingState, currentTarget, cellPx) {
+                                droppedPosition ->
+                              scope.launch {
+                                currentTargetAnimatable.snapTo(draggingState.offset)
+                                state.onDropPiece(piece, droppedPosition)
+                              }
+                            }
+                        else Modifier,
+                    )
                     .size(cellDp),
         )
       }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardState.kt
@@ -1,6 +1,11 @@
 package ch.epfl.sdp.mobile.ui.game
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.painter.Painter
+import ch.epfl.sdp.mobile.ui.*
+import ch.epfl.sdp.mobile.ui.BlackKing
+import ch.epfl.sdp.mobile.ui.i18n.LocalizedStrings
 
 /**
  * An interface which represents the state of a [ChessBoard] composable. It display the current
@@ -15,20 +20,60 @@ import androidx.compose.runtime.Stable
 @Stable
 interface ChessBoardState<Piece : ChessBoardState.Piece> {
 
-  /** The different ranks which may be displayed by a [ChessBoard]. */
-  enum class Rank {
-    King,
-    Queen,
-    Rook,
-    Bishop,
-    Knight,
-    Pawn,
+  /**
+   * The different ranks which may be displayed by a [ChessBoard].
+   *
+   * @param contentDescription the content description for this rank.
+   * @param whiteIcon the icon for the white variant of this rank.
+   * @param blackIcon the icon for the black variant of this rank.
+   */
+  enum class Rank(
+      val contentDescription: LocalizedStrings.() -> String,
+      val whiteIcon: @Composable () -> Painter,
+      val blackIcon: @Composable () -> Painter,
+  ) {
+    King(
+        contentDescription = { boardPieceKing },
+        whiteIcon = { ChessIcons.WhiteKing },
+        blackIcon = { ChessIcons.BlackKing },
+    ),
+    Queen(
+        contentDescription = { boardPieceQueen },
+        whiteIcon = { ChessIcons.WhiteQueen },
+        blackIcon = { ChessIcons.BlackQueen },
+    ),
+    Rook(
+        contentDescription = { boardPieceRook },
+        whiteIcon = { ChessIcons.WhiteRook },
+        blackIcon = { ChessIcons.BlackRook },
+    ),
+    Bishop(
+        contentDescription = { boardPieceBishop },
+        whiteIcon = { ChessIcons.WhiteBishop },
+        blackIcon = { ChessIcons.BlackBishop },
+    ),
+    Knight(
+        contentDescription = { boardPieceKnight },
+        whiteIcon = { ChessIcons.WhiteKnight },
+        blackIcon = { ChessIcons.BlackKnight },
+    ),
+    Pawn(
+        contentDescription = { boardPiecePawn },
+        whiteIcon = { ChessIcons.WhitePawn },
+        blackIcon = { ChessIcons.BlackPawn },
+    ),
   }
 
-  /** The different colors which may be displayed by a [ChessBoard]. */
-  enum class Color {
-    Black,
-    White,
+  /**
+   * The different colors which may be displayed by a [ChessBoard].
+   *
+   * @param contentDescription the content description for this color.
+   */
+  enum class Color(
+      val contentDescription: LocalizedStrings.() -> String,
+  ) {
+    Black(contentDescription = { boardColorBlack }),
+    White(contentDescription = { boardColorWhite }),
   }
 
   /**


### PR DESCRIPTION
This PR refactors the `ChessBoard` composable with its state.

- The icons and content descriptions are now stored in the `ChessBoardState.Rank` and `ChessBoardState.Color` enumerations.
- An important chunk of the drag & drop logic is extracted to its own `Modifier`.
- The `ChessBoard` supports a new `enabled` parameter.
- **(behaviour change)** Dropping a piece outside of the board no longer clamps the `ChessBoardState.Position`