### PR TITLE
Add a test that checks that the composition local for social facade throws if it's missing

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/CompositionLocalsTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/CompositionLocalsTest.kt
@@ -2,6 +2,7 @@ package ch.epfl.sdp.mobile.test.state
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import ch.epfl.sdp.mobile.state.LocalAuthenticationFacade
+import ch.epfl.sdp.mobile.state.LocalSocialFacade
 import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
@@ -14,6 +15,13 @@ class CompositionLocalsTest {
   fun missingAuthenticationApi_throwsException() {
     assertThrows(IllegalStateException::class.java) {
       rule.setContent { LocalAuthenticationFacade.current }
+    }
+  }
+
+  @Test
+  fun missingSocialFacade_throwsException() {
+    assertThrows(IllegalStateException::class.java) {
+      rule.setContent { LocalSocialFacade.current }
     }
   }
 }


### PR DESCRIPTION
This was missing in a previous PR (#99).

(side-note : the typo in the commit message is fixed in the squashed commit)