### PR TITLE
Add support for `@DocumentId` in `FakeStore`

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/Assertions.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/Assertions.kt
@@ -1,0 +1,25 @@
+package ch.epfl.sdp.mobile.test
+
+import com.google.common.truth.Truth
+import org.junit.Assert
+
+/**
+ * Asserts that the given [block] throws an exception or an error of type [T].
+ *
+ * @param T the expected type of the [Throwable].
+ * @param block the [block] under test.
+ */
+inline fun <reified T : Throwable> assertThrows(block: () -> Unit) {
+  var error = false
+  try {
+    block()
+    error = true
+  } catch (throwable: Throwable) {
+    if (throwable is T) {
+      Truth.assertThat(throwable).isInstanceOf(T::class.java)
+    }
+  }
+  if (error) {
+    Assert.fail("Expected an exception of type ${T::class.qualifiedName} but got nothing.")
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeCollectionReference.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeCollectionReference.kt
@@ -26,7 +26,7 @@ class FakeCollectionReference : CollectionReference, DocumentBuilder, FakeQuery 
 
   override fun document(path: String): FakeDocumentReference {
     return state.updateAndGetWithValue {
-      val (doc, ref) = it.documents.getOrPut(path) { FakeDocumentReference() }
+      val (doc, ref) = it.documents.getOrPut(path) { FakeDocumentReference(FakeDocumentId(path)) }
       it.copy(documents = doc) to ref
     }
   }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentDocumentIdTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentDocumentIdTest.kt
@@ -1,0 +1,56 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.Store
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.asFlow
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.set
+import ch.epfl.sdp.mobile.test.assertThrows
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.emptyStore
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.firestore.DocumentId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class FakeDocumentDocumentIdTest {
+
+  /** Returns a document reference with the given [name] from the [Store]. */
+  private fun Store.doc(name: String = "doc") = collection("users").document(name)
+
+  /** Returns a [Flow] to which [filterNotNull] and [first] are consecutively applied. */
+  private suspend fun <T : Any> Flow<T?>.firstNotNull() = filterNotNull().first()
+
+  data class DocumentWithAnnotationAndBadType(@DocumentId val id: Int? = null)
+  data class DocumentWithAnnotation(@DocumentId val id: String? = null)
+  data class DocumentWithoutAnnotation(val id: String? = null)
+
+  @Test
+  fun documentId_isPopulated() = runTest {
+    val store = emptyStore().apply { doc("doc").set(emptyMap()) }
+    assertThat(store.doc().asFlow<DocumentWithAnnotation>().firstNotNull().id).isEqualTo("doc")
+  }
+
+  @Test
+  fun documentId_appliedToNonStringProperty_throws() = runTest {
+    val store = emptyStore()
+    store.doc().set(emptyMap())
+    assertThrows<RuntimeException> {
+      store.doc().asFlow<DocumentWithAnnotationAndBadType>().firstNotNull()
+    }
+  }
+
+  @Test
+  fun documentId_set_isIgnored() = runTest {
+    val store = emptyStore()
+    store.doc(name = "doc").set(DocumentWithAnnotation(id = "Test"))
+    assertThat(store.doc().asFlow<DocumentWithoutAnnotation>().firstNotNull().id).isNull()
+  }
+
+  @Test
+  fun documentId_appliedToConflictingField_throws() = runTest {
+    val store = emptyStore()
+    store.doc().set(mapOf("id" to "Hello"))
+    assertThrows<RuntimeException> { store.doc().asFlow<DocumentWithAnnotation>().firstNotNull() }
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentId.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentId.kt
@@ -1,0 +1,16 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake
+
+/**
+ * A class representing the unique identifier of a [FakeDocumentRecord]. Within a collection, all
+ * documents are guaranteed to have different ids.
+ *
+ * @param value the value of the unique identifier.
+ */
+data class FakeDocumentId(val value: String) {
+
+  companion object {
+
+    /** The [FakeDocumentId] given to the root of the store. */
+    val Root = FakeDocumentId("")
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentReference.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentReference.kt
@@ -13,7 +13,7 @@ import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.*
 
-class FakeDocumentReference(id: FakeDocumentId): DocumentReference, CollectionBuilder {
+class FakeDocumentReference(id: FakeDocumentId) : DocumentReference, CollectionBuilder {
 
   data class State(
       val id: FakeDocumentId,

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentReference.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentReference.kt
@@ -13,14 +13,15 @@ import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.*
 
-class FakeDocumentReference : DocumentReference, CollectionBuilder {
+class FakeDocumentReference(id: FakeDocumentId): DocumentReference, CollectionBuilder {
 
   data class State(
+      val id: FakeDocumentId,
       val record: FakeDocumentRecord? = null,
       val collections: PersistentMap<String, FakeCollectionReference> = persistentMapOf(),
   )
 
-  val state = MutableStateFlow(State())
+  val state = MutableStateFlow(State(id))
 
   override fun collection(path: String): CollectionReference {
     return state.updateAndGetWithValue {
@@ -30,7 +31,7 @@ class FakeDocumentReference : DocumentReference, CollectionBuilder {
   }
 
   override fun asDocumentSnapshotFlow(): Flow<FakeDocumentSnapshot?> =
-      state.map { FakeDocumentSnapshot(it.record) }
+      state.map { FakeDocumentSnapshot(it.id, it.record) }
 
   override suspend fun delete() = state.update { it.copy(record = null) }
 

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentSnapshot.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentSnapshot.kt
@@ -7,10 +7,12 @@ import kotlin.reflect.KClass
 /**
  * A [DocumentSnapshot] which wraps a [FakeDocumentRecord].
  *
+ * @param id the document identifier.
  * @param record the (optional) [FakeDocumentRecord] which the snapshot wraps.
  */
 data class FakeDocumentSnapshot(
+    val id: FakeDocumentId,
     val record: FakeDocumentRecord?,
 ) : DocumentSnapshot {
-  override fun <T : Any> toObject(valueClass: KClass<T>): T? = record?.toObject(valueClass)
+  override fun <T : Any> toObject(valueClass: KClass<T>): T? = record?.toObject(id, valueClass)
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeStore.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeStore.kt
@@ -16,7 +16,7 @@ private constructor(
 ) : Store, CollectionBuilder by root {
 
   /** A convenience constructor, which creates an empty [FakeStore]. */
-  constructor() : this(FakeDocumentReference())
+  constructor() : this(FakeDocumentReference(FakeDocumentId.Root))
 
   override fun collection(path: String): CollectionReference = root.collection(path)
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/serialization/Records.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/serialization/Records.kt
@@ -1,10 +1,32 @@
 package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.serialization
 
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.FakeDocumentId
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.FakeDocumentRecord
+import com.google.firebase.firestore.DocumentId
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.typeOf
+
+/**
+ * Returns true if the given [KClass] has a declared field of the given name and annotated with an
+ * annotation of type [A]. Because [DocumentId] is a Java annotation, the Java APIs for reflection
+ * have to be used.
+ *
+ * @receiver the [KClass] that the field is searched on.
+ * @param name the name of the property.
+ * @return true iff there is a field with the given name annotated by [A].
+ */
+private inline fun <reified A : Annotation> KClass<*>.hasJavaAnnotatedField(name: String): Boolean =
+    try {
+      java.getDeclaredField(name).getDeclaredAnnotation(A::class.java) != null
+    } catch (noSuchField: NoSuchFieldException) {
+      false
+    }
+
+/** The set of [kotlin.reflect.KType] that will be accepted for [DocumentId]-annotated fields. */
+private val SupportedDocumentIdTypes = setOf(typeOf<String>(), typeOf<String?>())
 
 /**
  * Returns an object of type [T] using the provided [FakeDocumentRecord].
@@ -12,17 +34,24 @@ import kotlin.reflect.full.primaryConstructor
  * @param T the type of the returned object.
  *
  * @receiver the [FakeDocumentRecord] which is transformed.
+ * @param id the unique identifier for this document.
  * @param valueClass the [KClass] of the object to build.
  *
  * @return the T corresponding to the object to be built.
  */
-fun <T : Any> FakeDocumentRecord.toObject(valueClass: KClass<T>): T {
+fun <T : Any> FakeDocumentRecord.toObject(id: FakeDocumentId, valueClass: KClass<T>): T {
   require(valueClass.isData) { "Only data classes are currently supported." }
   val constructor = requireNotNull(valueClass.primaryConstructor) { "Missing a constructor." }
   val arguments = mutableMapOf<KParameter, Any?>()
   for (parameter in constructor.parameters) {
     val name = requireNotNull(parameter.name) { "Unnamed constructor parameter not supported." }
-    arguments[parameter] = fields[name]
+    if (valueClass.hasJavaAnnotatedField<DocumentId>(name)) {
+      require(parameter.type in SupportedDocumentIdTypes) { "DocumentId must be a String?." }
+      require(fields[name] == null) { "Found a document field with the same name as DocumentId." }
+      arguments[parameter] = id.value
+    } else {
+      arguments[parameter] = fields[name]
+    }
   }
   return constructor.callBy(arguments)
 }
@@ -42,7 +71,9 @@ fun <T : Any> FakeDocumentRecord.Companion.fromObject(
   require(valueClass.isData) { "Only data classes are currently supported." }
   val fields = mutableMapOf<String, Any?>()
   for (property in valueClass.memberProperties) {
-    fields[property.name] = property.get(value)
+    if (!valueClass.hasJavaAnnotatedField<DocumentId>(property.name)) {
+      fields[property.name] = property.get(value)
+    }
   }
   return FakeDocumentRecord(fields)
 }


### PR DESCRIPTION
PR #111 requires access to the document identifiers when performing some queries ([details here](https://github.com/epfl-SDP/android/pull/111#pullrequestreview-915144977)). Document identifiers will be needed in #142 as well.

This PR adds support for Document identifiers to `FakeStore` using the `@DocumentId` annotation from Firestore. Therefore, a `@DocumentId` annotation may be added to any `data class` representing a document in a `Store`.