### PR TITLE
Add a robot for the `ChessBoard` composable

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/AbstractRobot.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/AbstractRobot.kt
@@ -82,9 +82,9 @@ abstract class AbstractRobot(
    * @return the [SemanticsNodeInteraction] corresponding to the matched node.
    */
   fun onNodeWithLocalizedContentDescription(
-      substring: Boolean,
-      ignoreCase: Boolean,
-      useUnmergedTree: Boolean,
+      substring: Boolean = false,
+      ignoreCase: Boolean = false,
+      useUnmergedTree: Boolean = false,
       label: LocalizedStrings.() -> String,
   ): SemanticsNodeInteraction =
       onNodeWithContentDescription(
@@ -108,9 +108,9 @@ abstract class AbstractRobot(
    * @return the [SemanticsNodeInteractionCollection] corresponding to the matched nodes.
    */
   fun onAllNodesWithLocalizedContentDescription(
-      substring: Boolean,
-      ignoreCase: Boolean,
-      useUnmergedTree: Boolean,
+      substring: Boolean = false,
+      ignoreCase: Boolean = false,
+      useUnmergedTree: Boolean = false,
       label: LocalizedStrings.() -> String,
   ): SemanticsNodeInteractionCollection =
       onAllNodesWithContentDescription(

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/Layout.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/Layout.kt
@@ -1,5 +1,7 @@
 package ch.epfl.sdp.mobile.test.ui
 
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
@@ -25,5 +27,16 @@ fun SemanticsNode.getBoundsInRoot(): DpRect =
  * @return true if the offset is contained.
  */
 operator fun DpRect.contains(offset: DpOffset): Boolean {
+  return offset.x in left..right && offset.y in top..bottom
+}
+
+/**
+ * Returns true iff the [Offset] is contained within this [Rect] bounds.
+ *
+ * @receiver the bounds of the [Rect].
+ * @param offset the offset that we're checking some bounds for.
+ * @return true if the offset is contained.
+ */
+operator fun Rect.contains(offset: Offset): Boolean {
   return offset.x in left..right && offset.y in top..bottom
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardRobot.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardRobot.kt
@@ -55,6 +55,37 @@ interface ChessBoardRobotInputScope {
 }
 
 /**
+ * Performs a click gesture with the pointer with the given id at a specific position.
+ *
+ * @param x the x coordinate of the target cell.
+ * @param y the y coordinate of the target cell.
+ * @param pointerId the identifier of the pointer.
+ */
+fun ChessBoardRobotInputScope.click(x: Int, y: Int, pointerId: Int = 0) {
+  down(x = x, y = y, pointerId = pointerId)
+  // Required to send a move event. See TouchInjectionScope.click() for details.
+  moveBy(x = 0, y = 0, pointerId = pointerId)
+  up(pointerId = pointerId)
+}
+
+/**
+ * Performs a drag gesture between two positions with the pointer with the given id.
+ *
+ * @param from the original [ChessBoardState.Position].
+ * @param to the target [ChessBoardState.Position].
+ * @param pointerId the identifier of the pointer.
+ */
+fun ChessBoardRobotInputScope.drag(
+    from: ChessBoardState.Position,
+    to: ChessBoardState.Position,
+    pointerId: Int = 0,
+) {
+  down(x = from.x, y = from.y, pointerId = pointerId)
+  moveTo(x = to.x, y = to.y, pointerId = pointerId)
+  up(pointerId = pointerId)
+}
+
+/**
  * A robot which may be used to perform actions on a [ch.epfl.sdp.mobile.ui.game.ChessBoard]
  * composable.
  *

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardRobot.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardRobot.kt
@@ -1,0 +1,163 @@
+package ch.epfl.sdp.mobile.test.ui.game
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import ch.epfl.sdp.mobile.test.ui.AbstractRobot
+import ch.epfl.sdp.mobile.ui.game.ChessBoardState
+import ch.epfl.sdp.mobile.ui.i18n.LocalizedStrings
+
+/**
+ * An interface representing the operations which are available when interacting with the chess
+ * board. Inputs are performed in a coordinate system starting at the top left of the chessboard,
+ * with the x axis going towards the right and the y axis going towards the bottom.
+ *
+ * If the x or y coordinates are outside of the [0..8) range, inputs will NOT be clamped. This means
+ * you can drop pieces outside of the board.
+ */
+interface ChessBoardRobotInputScope {
+
+  /**
+   * Puts the pointer with the given id down on this cell.
+   *
+   * @param x the x coordinate at which the pointer goes down.
+   * @param y the y coordinate at which the pointer goes down.
+   * @param pointerId the identifier of the pointer.
+   */
+  fun down(x: Int, y: Int, pointerId: Int = 0)
+
+  /**
+   * Moves the pointer with the given id to this cell.
+   *
+   * @param x the x coordinate of the target cell.
+   * @param y the y coordinate of the target cell.
+   * @param pointerId the identifier of the pointer.
+   */
+  fun moveTo(x: Int, y: Int, pointerId: Int = 0)
+
+  /**
+   * Moves the pointer with the given id by a relative amount of cells.
+   *
+   * @param x the x delta.
+   * @param y the y delta.
+   * @param pointerId the identifier of the pointer.
+   */
+  fun moveBy(x: Int, y: Int, pointerId: Int = 0)
+
+  /**
+   * Moves the pointer with the given id up, finishing a gesture.
+   *
+   * @param pointerId the identifier of the pointer.
+   */
+  fun up(pointerId: Int = 0)
+}
+
+/**
+ * A robot which may be used to perform actions on a [ch.epfl.sdp.mobile.ui.game.ChessBoard]
+ * composable.
+ *
+ * @param rule the underlying [ComposeTestRule].
+ * @param strings the [LocalizedStrings] for the composition.
+ */
+class ChessBoardRobot(
+    rule: ComposeTestRule,
+    strings: LocalizedStrings,
+) : AbstractRobot(rule, strings) {
+
+  /** Returns the [SemanticsNodeInteraction] corresponding to the chessboard. */
+  private fun onChessBoard(): SemanticsNodeInteraction {
+    return onNodeWithLocalizedContentDescription { boardContentDescription }
+  }
+
+  /**
+   * Performs the inputs specified in the [ChessBoardRobotInputScope] on the chessboard.
+   *
+   * @param scope the [ChessBoardRobotInputScope] in which the inputs are performed.
+   */
+  fun performInput(scope: ChessBoardRobotInputScope.() -> Unit) {
+    val sizeInfo = BoardSizeInfo(onChessBoard())
+    onChessBoard().performTouchInput { SizeInfoChessBoardInputScope(sizeInfo, this).apply(scope) }
+  }
+
+  /**
+   * Asserts that a piece with the given [color] and [rank] is present at the given position. This
+   * will essentially check that the center of the piece is present in a specific cell.
+   *
+   * @param x the first coordinate of the cell.
+   * @param y the second coordinate of the cell.
+   * @param color the [ChessBoardState.Color] to check for.
+   * @param rank the [ChessBoardState.Rank] to check for.
+   */
+  fun assertHasPiece(x: Int, y: Int, color: ChessBoardState.Color, rank: ChessBoardState.Rank) {
+    val boardBounds = onChessBoard().fetchSemanticsNode().boundsInRoot
+    val sizeInfo = BoardSizeInfo(onChessBoard())
+    val matcher =
+        SemanticsMatcher("positionInBounds") { piece ->
+          val bounds =
+              Rect(
+                      offset = boardBounds.topLeft,
+                      size = Size(sizeInfo.squareSize, sizeInfo.squareSize),
+                  )
+                  .translate(x * sizeInfo.squareSize, y * sizeInfo.squareSize)
+          bounds.contains(piece.boundsInRoot.center)
+        }
+    onAllNodesWithLocalizedContentDescription {
+          boardPieceContentDescription(
+              color.contentDescription(this),
+              rank.contentDescription(this),
+          )
+        }
+        .assertAny(matcher)
+  }
+}
+
+/**
+ * A helper class which computes some size information related to a board.
+ *
+ * @param interaction the [SemanticsNodeInteraction] to access the board.
+ */
+private class BoardSizeInfo(interaction: SemanticsNodeInteraction) {
+  /** The size of the board. */
+  val size = interaction.fetchSemanticsNode().size
+
+  /** The int size corresponding to half a square. */
+  val halfSquare = Offset(size.height / 16f, size.width / 16f)
+
+  /** The dimensions of a square of the board. */
+  val squareSize = minOf(size.height, size.width) / 8f
+}
+
+/**
+ * An implementation of [ChessBoardRobotInputScope] which delegates interactions to a
+ * [TouchInjectionScope].
+ *
+ * @param sizeInfo the [BoardSizeInfo] to access basic information from the board.
+ * @param scope the [TouchInjectionScope] in which the interactions are performed.
+ */
+private class SizeInfoChessBoardInputScope(
+    private val sizeInfo: BoardSizeInfo,
+    private val scope: TouchInjectionScope,
+) : ChessBoardRobotInputScope {
+
+  override fun down(x: Int, y: Int, pointerId: Int) =
+      scope.down(
+          pointerId = pointerId,
+          position = Offset(x * sizeInfo.squareSize, y * sizeInfo.squareSize) + sizeInfo.halfSquare,
+      )
+
+  override fun moveTo(x: Int, y: Int, pointerId: Int) =
+      scope.moveTo(
+          pointerId = pointerId,
+          position = Offset(x * sizeInfo.squareSize, y * sizeInfo.squareSize) + sizeInfo.halfSquare,
+      )
+
+  override fun moveBy(x: Int, y: Int, pointerId: Int) =
+      scope.moveBy(
+          pointerId = pointerId,
+          delta = Offset(x * sizeInfo.squareSize, y * sizeInfo.squareSize),
+      )
+
+  override fun up(pointerId: Int) = scope.up(pointerId = pointerId)
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
@@ -1,19 +1,10 @@
 package ch.epfl.sdp.mobile.test.ui.game
 
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import ch.epfl.sdp.mobile.test.state.setContentWithLocalizedStrings
-import ch.epfl.sdp.mobile.test.ui.contains
-import ch.epfl.sdp.mobile.test.ui.getBoundsInRoot
 import ch.epfl.sdp.mobile.ui.game.ChessBoard
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Color.White
@@ -62,35 +53,25 @@ class ChessBoardTest {
   @Test
   fun draggingPawnAroundIsSuccessful() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
-    val strings =
-        rule.setContentWithLocalizedStrings {
-          ChessBoard(state, Modifier.size(160.dp).testTag("board"))
-        }
-    rule.onNodeWithTag("board").performTouchInput {
-      down(Offset(10.dp.toPx(), 10.dp.toPx()))
-      moveBy(Offset(0.dp.toPx(), 40.dp.toPx()))
+    val strings = rule.setContentWithLocalizedStrings { ChessBoard(state) }
+    val robot = ChessBoardRobot(rule, strings)
+    robot.performInput {
+      down(0, 0)
+      moveBy(0, 2)
       up()
     }
     rule.awaitIdle()
-    val inBounds =
-        rule.onAllNodesWithContentDescription(
-                strings.boardPieceContentDescription(
-                    strings.boardColorWhite, strings.boardPiecePawn),
-            )
-            .fetchSemanticsNodes()
-            .any { DpOffset(10.dp, 50.dp) in it.getBoundsInRoot() }
-    assertThat(inBounds).isTrue()
+    robot.assertHasPiece(0, 2, White, Pawn)
   }
 
   @Test
   fun draggingPawnOutsideBoard_works() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
-    rule.setContentWithLocalizedStrings {
-      ChessBoard(state, Modifier.size(160.dp).testTag("board"))
-    }
-    rule.onNodeWithTag("board").performTouchInput {
-      down(Offset(10.dp.toPx(), 10.dp.toPx()))
-      moveBy(Offset(-20.dp.toPx(), -20.dp.toPx()))
+    val strings = rule.setContentWithLocalizedStrings { ChessBoard(state) }
+    val robot = ChessBoardRobot(rule, strings)
+    robot.performInput {
+      down(0, 0)
+      moveBy(-1, -1)
       up()
     }
     assertThat(state.position).isEqualTo(Position(-1, -1))
@@ -99,93 +80,60 @@ class ChessBoardTest {
   @Test
   fun draggingPawnAround_withDisabledBoard_movesNothing() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
-    val strings =
-        rule.setContentWithLocalizedStrings {
-          ChessBoard(state, Modifier.size(160.dp).testTag("board"), enabled = false)
-        }
-    rule.onNodeWithTag("board").performTouchInput {
-      down(Offset(10.dp.toPx(), 10.dp.toPx()))
-      moveBy(Offset(0.dp.toPx(), 40.dp.toPx()))
+    val strings = rule.setContentWithLocalizedStrings { ChessBoard(state, enabled = false) }
+    val robot = ChessBoardRobot(rule, strings)
+    robot.performInput {
+      down(0, 0)
+      moveBy(0, 2)
       up()
     }
-    val bounds =
-        rule.onNodeWithContentDescription(
-                strings.boardPieceContentDescription(
-                    strings.boardColorWhite, strings.boardPiecePawn),
-            )
-            .getBoundsInRoot()
-    assertThat(DpOffset(10.dp, 10.dp) in bounds).isTrue()
+    robot.assertHasPiece(0, 0, White, Pawn)
   }
 
   @Test
   fun draggingPawnAround_whileBoardIsEnabled_dropsOnRightTarget() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
-    val strings =
-        rule.setContentWithLocalizedStrings {
-          ChessBoard(state, Modifier.size(160.dp).testTag("board"))
-        }
-    rule.onNodeWithTag("board").performTouchInput {
-      down(Offset(10.dp.toPx(), 10.dp.toPx()))
-      moveBy(Offset(0.dp.toPx(), 20.dp.toPx()))
+    val strings = rule.setContentWithLocalizedStrings { ChessBoard(state) }
+    val robot = ChessBoardRobot(rule, strings)
+    robot.performInput {
+      down(0, 0)
+      moveBy(0, 1)
     }
     state.position = Position(1, 1)
-    rule.onNodeWithTag("board").performTouchInput {
-      moveBy(Offset(0.dp.toPx(), 20.dp.toPx())) // Still drop at (0, 3)
+    robot.performInput {
+      moveBy(0, 1) // Still drop at (0, 2)
       up()
     }
-    val bounds =
-        rule.onNodeWithContentDescription(
-                strings.boardPieceContentDescription(
-                    strings.boardColorWhite, strings.boardPiecePawn),
-            )
-            .getBoundsInRoot()
-    assertThat(DpOffset(10.dp, 50.dp) in bounds).isTrue()
+    robot.assertHasPiece(0, 2, White, Pawn)
   }
 
   @Test
   fun emptyDragGesture_doesNotMovePawn() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
-    val strings =
-        rule.setContentWithLocalizedStrings {
-          ChessBoard(state, Modifier.size(160.dp).testTag("board"))
-        }
-    rule.onNodeWithTag("board").performTouchInput {
-      down(Offset(10.dp.toPx(), 10.dp.toPx()))
-      cancel() // Cancel the gesture, so we should not drop the pawn.
+    val strings = rule.setContentWithLocalizedStrings { ChessBoard(state) }
+    val robot = ChessBoardRobot(rule, strings)
+    robot.performInput {
+      down(0, 0)
+      up()
     }
-    rule.awaitIdle()
-    val bounds =
-        rule.onNodeWithContentDescription(
-                strings.boardPieceContentDescription(
-                    strings.boardColorWhite, strings.boardPiecePawn),
-            )
-            .getBoundsInRoot()
-    assertThat(DpOffset(10.dp, 10.dp) in bounds).isTrue()
+    robot.assertHasPiece(0, 0, White, Pawn)
   }
 
   @Test
   fun disablingBoardDuringDrag_dropsPiece() = runTest {
     val state = SinglePieceSnapshotChessBoardState()
     var enabled by mutableStateOf(true)
-    val strings =
-        rule.setContentWithLocalizedStrings {
-          ChessBoard(state, Modifier.size(160.dp).testTag("board"), enabled = enabled)
-        }
-    rule.onNodeWithTag("board").performTouchInput {
-      down(Offset(10.dp.toPx(), 10.dp.toPx()))
-      moveBy(Offset(0.dp.toPx(), 20.dp.toPx()))
+    val strings = rule.setContentWithLocalizedStrings { ChessBoard(state, enabled = enabled) }
+    val robot = ChessBoardRobot(rule, strings)
+    robot.performInput {
+      down(0, 0)
+      moveBy(0, 1)
     }
     enabled = false // We expect the piece to be dropped mid-gesture.
-    rule.onNodeWithTag("board").performTouchInput {
-      moveBy(Offset(0.dp.toPx(), 20.dp.toPx()))
+    robot.performInput {
+      moveBy(0, 1)
       up()
     }
-    val bounds =
-        rule.onNodeWithContentDescription(
-                strings.boardPieceContentDescription(
-                    strings.boardColorWhite, strings.boardPiecePawn),
-            )
-            .getBoundsInRoot()
-    assertThat(DpOffset(10.dp, 30.dp) in bounds).isTrue()
+    robot.assertHasPiece(0, 1, White, Pawn)
   }
 }


### PR DESCRIPTION
This is part of the refactoring required of #153. This pull request adds a `ChessBoardRobot`, and updates some existing chessboard tests to use it.