### PR TITLE
Display the check status on the chessboard

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulGameScreenTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulGameScreenTest.kt
@@ -137,7 +137,7 @@ class StatefulGameScreenTest {
     val socialFacade = SocialFacade(auth, store)
     val chessFacade = ChessFacade(auth, store)
     val user = mockk<AuthenticatedUser>()
-    every { user.uid } returns "id1"
+    every { user.uid } returns "id"
 
     val strings =
         rule.setContentWithLocalizedStrings {
@@ -150,9 +150,9 @@ class StatefulGameScreenTest {
     robot.performInput {
       drag(ChessBoardState.Position(4, 6), ChessBoardState.Position(4, 5))
       drag(ChessBoardState.Position(5, 1), ChessBoardState.Position(5, 2))
-      drag(ChessBoardState.Position(3, 7), ChessBoardState.Position(7, 4))
+      drag(ChessBoardState.Position(3, 7), ChessBoardState.Position(7, 3))
     }
-    rule.mainClock.advanceTimeByFrame() // Ensures we display the selected state.
+    rule.mainClock.advanceTimeByFrame() // Ensures we display the check state.
     robot.performInput { drag(ChessBoardState.Position(6, 1), ChessBoardState.Position(6, 2)) }
     robot.assertHasPiece(6, 2, Black, Pawn)
   }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
@@ -37,6 +37,7 @@ class ChessBoardTest {
     var position: Position by mutableStateOf(Position(0, 0))
 
     override val selectedPosition: Position? = null
+    override val checkPosition: Position? = null
 
     override val pieces: Map<Position, Piece>
       get() = mapOf(position to piece)

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulGameScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulGameScreen.kt
@@ -74,6 +74,18 @@ class SnapshotChessBoardState(
   override var selectedPosition by mutableStateOf<ChessBoardState.Position?>(null)
     private set
 
+  override val checkPosition: ChessBoardState.Position?
+    get() {
+      val nextStep = match.game.nextStep
+      if (nextStep !is NextStep.MovePiece || !nextStep.inCheck) return null
+      return match
+          .game
+          .board
+          .firstOrNull { (_, piece) -> piece.color == nextStep.turn && piece.rank == Rank.King }
+          ?.first
+          ?.toPosition()
+    }
+
   override val pieces: Map<ChessBoardState.Position, SnapshotPiece>
     get() =
         match

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulGameScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulGameScreen.kt
@@ -81,9 +81,9 @@ class SnapshotChessBoardState(
       return match
           .game
           .board
-          .firstOrNull { (_, piece) -> piece.color == nextStep.turn && piece.rank == Rank.King }
-          ?.first
-          ?.toPosition()
+          .first { (_, piece) -> piece.color == nextStep.turn && piece.rank == Rank.King }
+          .first
+          .toPosition()
     }
 
   override val pieces: Map<ChessBoardState.Position, SnapshotPiece>

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoard.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoard.kt
@@ -57,6 +57,10 @@ fun <Piece : ChessBoardState.Piece> ChessBoard(
               cells = ChessBoardCells,
               color = MaterialTheme.colors.onPrimary.copy(alpha = ContentAlpha.disabled),
           )
+          .check(
+              position = state.checkPosition,
+              color = MaterialTheme.colors.secondary.copy(alpha = ContentAlpha.medium),
+          )
           .grid(cells = ChessBoardCells, color = MaterialTheme.colors.primary)
           .actions(
               positions = state.availableMoves,

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardModifiers.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardModifiers.kt
@@ -107,6 +107,25 @@ fun Modifier.actions(
   }
 }
 
+/**
+ * A [Modifier] which draws a position that is currently in check.
+ *
+ * @param position the position that should be drawn.
+ * @param color the [Color] of the background for check.
+ * @param cells the number of cells in the grid.
+ */
+fun Modifier.check(
+    position: ChessBoardState.Position?,
+    color: Color = Color.Unspecified,
+    cells: Int = ChessBoardCells,
+): Modifier = composed {
+  val fillColor = color.takeOrElse { LocalContentColor.current }
+  cells(
+      positions = position?.let(::setOf) ?: emptySet(),
+      cells = cells,
+  ) { drawRect(fillColor) }
+}
+
 /** The duration of a cycle of the selection dashed border animation. */
 private const val SelectionDurationMillis = DefaultDurationMillis * 4
 

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardState.kt
@@ -102,6 +102,9 @@ interface ChessBoardState<Piece : ChessBoardState.Piece> {
   /** Returns the position currently selected by the user, if there's any. */
   val selectedPosition: Position?
 
+  /** Returns the position of the [Rank.King] currently in check, if there's any. */
+  val checkPosition: Position?
+
   /**
    * A [Set] of the positions which are available to the player for actions, depending on the pieces
    * which they are currently holding.


### PR DESCRIPTION
This PR adds a solid color indicator on the background the king pieces if the player is currently in check.