### PR TITLE
Fix navigation reloading when the profile gets updated

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/NavigationTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/NavigationTest.kt
@@ -1,17 +1,22 @@
 package ch.epfl.sdp.mobile.test.state
 
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsProperties.Selected
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.SemanticsMatcher.Companion.expectValue
 import androidx.compose.ui.test.SemanticsMatcher.Companion.keyIsDefined
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithText
+import ch.epfl.sdp.mobile.application.ProfileDocument
 import ch.epfl.sdp.mobile.application.authentication.AuthenticationFacade
 import ch.epfl.sdp.mobile.application.chess.ChessFacade
 import ch.epfl.sdp.mobile.application.social.SocialFacade
 import ch.epfl.sdp.mobile.state.Navigation
 import ch.epfl.sdp.mobile.state.ProvideFacades
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.SuspendingAuth
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.buildAuth
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.auth.emptyAuth
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.buildStore
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.document
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.emptyStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -66,5 +71,31 @@ class NavigationTest {
     rule.onNodeWithText(strings.sectionSocial).assertExists()
     rule.onNodeWithText(strings.sectionSettings).assertExists()
     rule.onNodeWithText(strings.sectionPlay).assertExists()
+  }
+
+  @Test
+  fun updatingUsername_preservesHomeSection() = runTest {
+    val auth = buildAuth { user("email", "password", "id") }
+    val store = buildStore {
+      collection("users") { document("id", ProfileDocument(name = "Alice")) }
+    }
+    val authFacade = AuthenticationFacade(auth, store)
+    val chessFacade = ChessFacade(auth, store)
+    val socialFacade = SocialFacade(auth, store)
+    val strings =
+        rule.setContentWithLocalizedStrings {
+          ProvideFacades(authFacade, socialFacade, chessFacade) { Navigation() }
+        }
+    authFacade.signInWithEmail("email", "password")
+
+    // Move to the profile section.
+    rule.onNodeWithText(strings.sectionSettings).performClick()
+    rule.onAllNodesWithText(strings.sectionSettings).assertAny(expectValue(Selected, true))
+
+    // Update the username.
+    store.collection("users").document("id").update { this["name"] = "Bob" }
+
+    // Check that we're still in the right section.
+    rule.onAllNodesWithText(strings.sectionSettings).assertAny(expectValue(Selected, true))
   }
 }


### PR DESCRIPTION
This PR fixes #195. A regression test is added, which checks that updating the profile won't change the current navigation section, and a fix is added.

The issue was caused by improper equality checks on `UserState` in the `Crossfade` composable. If the username (or any profile field) was updated, the `UserState` was different and the `Crossfade` would animate to the next state, essentially creating a new body composable.

By specifying an explicit `key` in an `AnimatedContent`, user field updates won't be considered as if a new user had logged in, and navigation reloading will be fixed.