### PR TITLE
Add support for the `orderBy` operator to `Store`

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/DslOrderingTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/DslOrderingTest.kt
@@ -1,0 +1,38 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.asFlow
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.set
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.firestore.DocumentId
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DslOrderingTest {
+
+  data class AnyDocument(val value: Any?, @DocumentId val name: String? = null)
+  data class BooleanDocument(val value: Boolean?, @DocumentId val name: String? = null)
+  data class NumberDocument(val value: Number?, @DocumentId val name: String? = null)
+  data class StringDocument(val value: String?, @DocumentId val name: String? = null)
+
+  @Test
+  fun oneNullValueHasNoOrder() = runTest {
+    val store = buildStore { collection("docs") { document("a", AnyDocument(null)) } }
+    val list = store.collection("docs").orderBy("value").asFlow<AnyDocument>().first()
+    assertThat(list).containsExactly(AnyDocument(null, "a"))
+  }
+
+  @Test
+  fun insertingNumbersUpTo100_areReadInOrder() = runTest {
+    val store = emptyStore()
+    val numbers = List(100) { it }
+    numbers.shuffled().forEach { number ->
+      store.collection("numbers").document().set(NumberDocument(number))
+    }
+    val list =
+        store.collection("numbers").orderBy("value").asFlow<NumberDocument>().first().map { doc ->
+          requireNotNull(doc?.value)
+        }
+    assertThat(list).isEqualTo(numbers)
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/Comparisons.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/Comparisons.kt
@@ -1,0 +1,104 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.query
+
+import kotlin.reflect.KClass
+
+// The Firestore reference [1] defines a strict ordering for mixed types, written below. Currently
+// unsupported data types by the FakeStore are marked as [UNSUPPORTED]. Unsupported types will throw
+// some exceptions when being compared.
+//
+//  1. Null values
+//  2. Boolean values, with false < true
+//  3. Integer and floating point values, sorted in numerical order
+//  4. [UNSUPPORTED] Date values
+//  5. Text string values
+//  6. [UNSUPPORTED] Byte values
+//  7. [UNSUPPORTED] Cloud Firestore references
+//  8. [UNSUPPORTED] Geographical point values, by latitude then longitude
+//  9. [UNSUPPORTED] Array values, by lexicographic order
+// 10. [UNSUPPORTED] Map values, by keys then by values
+//
+// [1] : https://firebase.google.com/docs/firestore/manage-data/data-types
+
+/** The array of groups of KClass, sorted by their relative importance. */
+private val TypesAscending =
+    arrayOf(
+        arrayOf(Boolean::class),
+        arrayOf(Number::class, Int::class, Long::class, Short::class, Float::class, Double::class),
+        arrayOf(String::class),
+    )
+
+// Ordering values.
+private const val SmallestFirst = -1
+private const val Equal = 0
+private const val GreatestFirst = 1
+
+/** The [Comparator] which should be used to perform some comparisons across the generic values. */
+val FakeFieldComparator: Comparator<Any?> = Comparator { a, b ->
+
+  // Null values are always the smallest.
+  if (a == null && b == null) return@Comparator Equal
+  if (a == null) return@Comparator SmallestFirst
+  if (b == null) return@Comparator GreatestFirst
+
+  // Retrieve the type indices of both a and b. If either of them is a null value, throw an
+  // exception, since we don't support matching on these types yet.
+  val aTypeIndex = TypesAscending.indexOfFirstOrNull { a::class in it } ?: badType(a::class)
+  val bTypeIndex = TypesAscending.indexOfFirstOrNull { b::class in it } ?: badType(b::class)
+
+  // Ensure both indices are well-defined and in the table.
+  return@Comparator when {
+    aTypeIndex == bTypeIndex && a::class in TypesAscending[0] -> compareBoolean(a, b)
+    aTypeIndex == bTypeIndex && a::class in TypesAscending[1] -> compareNumber(a, b)
+    aTypeIndex == bTypeIndex && a::class in TypesAscending[2] -> compareString(a, b)
+    else -> aTypeIndex - bTypeIndex // Both indices are different
+  }
+}
+
+/**
+ * Indicates that the given type is not supported.
+ *
+ * @param type the unsupported type.
+ */
+private fun badType(
+    type: KClass<*>?,
+): Nothing = error("Type $type is not supported in FakeQuery.orderBy yet.")
+
+/**
+ * Returns the first index matching the given predicate, or null.
+ *
+ * @param T the type of the elements of the array.
+ * @return the [Array] for which the predicate is checked.
+ * @param predicate the predicate to check for.
+ * @return the nullable index.
+ */
+private inline fun <T> Array<out T>.indexOfFirstOrNull(predicate: (T) -> Boolean): Int? {
+  val index = indexOfFirst(predicate = predicate)
+  return if (index == -1) null else index
+}
+
+/** Compares the values [a] and [b] as booleans. */
+private fun compareBoolean(a: Any, b: Any): Int {
+  a as Boolean
+  b as Boolean
+  // Boolean.compareTo(Boolean) seems to have some issues on some devices, and fails with a
+  // ClassCastException on my phone. However, manually checking the ordering works fine.
+  return when (a) {
+    b -> Equal
+    false -> SmallestFirst
+    else -> GreatestFirst
+  }
+}
+
+/** Compares the values [a] and [b] as numbers. */
+private fun compareNumber(a: Any, b: Any): Int {
+  a as Number
+  b as Number
+  return a.toDouble().compareTo(b.toDouble())
+}
+
+/** Compares the values [a] and [b] as strings. */
+private fun compareString(a: Any, b: Any): Int {
+  a as String
+  b as String
+  return a.compareTo(b)
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/FakeQuery.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/FakeQuery.kt
@@ -22,6 +22,24 @@ interface FakeQuery : Query {
   override fun orderBy(field: String, direction: Query.Direction): FakeQuery =
       OrderByQueryDecorator(this, field, direction)
 
+  override fun whereGreaterThan(field: String, value: Any, inclusive: Boolean): FakeQuery =
+      WhereFakeQueryDecorator(
+          this.whereNotEquals(field, null),
+          where(field) {
+            val bound = if (inclusive) 0 else 1
+            FakeFieldComparator.compare(it, value) >= bound
+          },
+      )
+
+  override fun whereLessThan(field: String, value: Any, inclusive: Boolean): FakeQuery =
+      WhereFakeQueryDecorator(
+          this.whereNotEquals(field, null),
+          where(field) {
+            val bound = if (inclusive) 0 else -1
+            FakeFieldComparator.compare(it, value) <= bound
+          },
+      )
+
   override fun whereEquals(field: String, value: Any?): FakeQuery =
       WhereFakeQueryDecorator(this, where(field) { it == value })
 

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/FakeQuery.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/FakeQuery.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.flow.Flow
 interface FakeQuery : Query {
   override fun limit(count: Long): FakeQuery = LimitFakeQueryDecorator(this, count)
 
+  override fun orderBy(field: String, direction: Query.Direction): FakeQuery =
+      OrderByQueryDecorator(this, field, direction)
+
   override fun whereEquals(field: String, value: Any?): FakeQuery =
       WhereFakeQueryDecorator(this, where(field) { it == value })
 

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/OrderByQueryDecorator.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/OrderByQueryDecorator.kt
@@ -4,13 +4,12 @@ import ch.epfl.sdp.mobile.infrastructure.persistence.store.Query
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.FakeDocumentSnapshot
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.FakeQuerySnapshot
 import kotlin.Comparator
-import kotlin.reflect.KClass
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 /**
- * A decorator which orders results according to a certain [Comparator] on the resulting document
- * snapshots.
+ * A decorator which orders results according to a certain [FakeFieldComparator] on the resulting
+ * document snapshots.
  *
  * @param query the query to decorate.
  * @param field the field to compare.
@@ -25,112 +24,11 @@ class OrderByQueryDecorator(
   override fun asQuerySnapshotFlow(): Flow<FakeQuerySnapshot> {
     val comparator =
         Comparator<FakeDocumentSnapshot> { a, b ->
-          Comparator.compare(a?.record?.fields?.get(field), b?.record?.fields?.get(field))
+          FakeFieldComparator.compare(a?.record?.fields?.get(field), b?.record?.fields?.get(field))
         }
     val withOrder = if (order == Query.Direction.Ascending) comparator else comparator.reversed()
     return query.asQuerySnapshotFlow().map {
       it.copy(documents = it.documents.sortedWith(withOrder))
     }
   }
-}
-
-// The Firestore reference [1] defines a strict ordering for mixed types, written below. Currently
-// unsupported data types by the FakeStore are marked as [UNSUPPORTED]. Unsupported types will throw
-// some exceptions when being compared.
-//
-//  1. Null values
-//  2. Boolean values, with false < true
-//  3. Integer and floating point values, sorted in numerical order
-//  4. [UNSUPPORTED] Date values
-//  5. Text string values
-//  6. [UNSUPPORTED] Byte values
-//  7. [UNSUPPORTED] Cloud Firestore references
-//  8. [UNSUPPORTED] Geographical point values, by latitude then longitude
-//  9. [UNSUPPORTED] Array values, by lexicographic order
-// 10. [UNSUPPORTED] Map values, by keys then by values
-//
-// [1] : https://firebase.google.com/docs/firestore/manage-data/data-types
-
-/** The array of groups of KClass, sorted by their relative importance. */
-private val TypesAscending =
-    arrayOf(
-        arrayOf(Boolean::class),
-        arrayOf(Number::class, Int::class, Long::class, Short::class, Float::class, Double::class),
-        arrayOf(String::class),
-    )
-
-// Ordering values.
-private const val SmallestFirst = -1
-private const val Equal = 0
-private const val GreatestFirst = 1
-
-/** The [Comparator] which should be used to perform some comparisons across the generic values. */
-private val Comparator: Comparator<Any?> = Comparator { a, b ->
-
-  // Null values are always the smallest.
-  if (a == null && b == null) return@Comparator Equal
-  if (a == null) return@Comparator SmallestFirst
-  if (b == null) return@Comparator GreatestFirst
-
-  // Retrieve the type indices of both a and b. If either of them is a null value, throw an
-  // exception, since we don't support matching on these types yet.
-  val aTypeIndex = TypesAscending.indexOfFirstOrNull { a::class in it } ?: badType(a::class)
-  val bTypeIndex = TypesAscending.indexOfFirstOrNull { b::class in it } ?: badType(b::class)
-
-  // Ensure both indices are well-defined and in the table.
-  return@Comparator when {
-    aTypeIndex == bTypeIndex && a::class in TypesAscending[0] -> compareBoolean(a, b)
-    aTypeIndex == bTypeIndex && a::class in TypesAscending[1] -> compareNumber(a, b)
-    aTypeIndex == bTypeIndex && a::class in TypesAscending[2] -> compareString(a, b)
-    else -> aTypeIndex - bTypeIndex // Both indices are different
-  }
-}
-
-/**
- * Indicates that the given type is not supported.
- *
- * @param type the unsupported type.
- */
-private fun badType(
-    type: KClass<*>?,
-): Nothing = error("Type $type is not supported in FakeQuery.orderBy yet.")
-
-/**
- * Returns the first index matching the given predicate, or null.
- *
- * @param T the type of the elements of the array.
- * @return the [Array] for which the predicate is checked.
- * @param predicate the predicate to check for.
- * @return the nullable index.
- */
-private inline fun <T> Array<out T>.indexOfFirstOrNull(predicate: (T) -> Boolean): Int? {
-  val index = indexOfFirst(predicate = predicate)
-  return if (index == -1) null else index
-}
-
-/** Compares the values [a] and [b] as booleans. */
-private fun compareBoolean(a: Any, b: Any): Int {
-  a as Boolean
-  b as Boolean
-  // Boolean.compareTo(Boolean) seems to have some issues on some devices, and fails with a
-  // ClassCastException on my phone. However, manually checking the ordering works fine.
-  return when (a) {
-    b -> Equal
-    false -> SmallestFirst
-    else -> GreatestFirst
-  }
-}
-
-/** Compares the values [a] and [b] as numbers. */
-private fun compareNumber(a: Any, b: Any): Int {
-  a as Number
-  b as Number
-  return a.toDouble().compareTo(b.toDouble())
-}
-
-/** Compares the values [a] and [b] as strings. */
-private fun compareString(a: Any, b: Any): Int {
-  a as String
-  b as String
-  return a.compareTo(b)
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/OrderByQueryDecorator.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/OrderByQueryDecorator.kt
@@ -1,0 +1,136 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.query
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.Query
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.FakeDocumentSnapshot
+import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake.FakeQuerySnapshot
+import kotlin.Comparator
+import kotlin.reflect.KType
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.full.isSupertypeOf
+import kotlin.reflect.typeOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * A decorator which orders results according to a certain [Comparator] on the resulting document
+ * snapshots.
+ *
+ * @param query the query to decorate.
+ * @param field the field to compare.
+ * @param order the direction of the comparison.
+ */
+class OrderByQueryDecorator(
+    private val query: FakeQuery,
+    private val field: String,
+    private val order: Query.Direction,
+) : FakeQuery {
+
+  override fun asQuerySnapshotFlow(): Flow<FakeQuerySnapshot> {
+    val comparator =
+        Comparator<FakeDocumentSnapshot> { a, b ->
+          Comparator.compare(a?.record?.fields?.get(field), b?.record?.fields?.get(field))
+        }
+    val withOrder = if (order == Query.Direction.Ascending) comparator else comparator.reversed()
+    return query.asQuerySnapshotFlow().map {
+      it.copy(documents = it.documents.sortedWith(withOrder))
+    }
+  }
+}
+
+// The Firestore reference [1] defines a strict ordering for mixed types, written below. Currently
+// unsupported data types by the FakeStore are marked as [UNSUPPORTED]. Unsupported types will throw
+// some exceptions when being compared.
+//
+//  1. Null values
+//  2. Boolean values, with false < true
+//  3. Integer and floating point values, sorted in numerical order
+//  4. [UNSUPPORTED] Date values
+//  5. Text string values
+//  6. [UNSUPPORTED] Byte values
+//  7. [UNSUPPORTED] Cloud Firestore references
+//  8. [UNSUPPORTED] Geographical point values, by latitude then longitude
+//  9. [UNSUPPORTED] Array values, by lexicographic order
+// 10. [UNSUPPORTED] Map values, by keys then by values
+//
+// [1] : https://firebase.google.com/docs/firestore/manage-data/data-types
+
+/** The array of KType, sorted by their relative importance. */
+private val TypesAscending = arrayOf(typeOf<Boolean>(), typeOf<Number>(), typeOf<String>())
+
+// Ordering values.
+private const val SmallestFirst = -1
+private const val Equal = 0
+private const val GreatestFirst = 1
+
+/** The [Comparator] which should be used to perform some comparisons across the generic values. */
+private val Comparator: Comparator<Any?> = Comparator { a, b ->
+
+  // Null values are always the smallest.
+  if (a == null && b == null) return@Comparator Equal
+  if (a == null) return@Comparator SmallestFirst
+  if (b == null) return@Comparator GreatestFirst
+
+  // Retrieve the type indices of both a and b. If either of them is a null value, throw an
+  // exception, since we don't support matching on these types yet.
+  val aType = a::class.createType()
+  val bType = b::class.createType()
+  val aTypeIndex = TypesAscending.indexOfFirstOrNull { it.isSupertypeOf(aType) } ?: badType(aType)
+  val bTypeIndex = TypesAscending.indexOfFirstOrNull { it.isSupertypeOf(bType) } ?: badType(bType)
+
+  // Ensure both indices are well-defined and in the table.
+  return@Comparator when {
+    aTypeIndex == bTypeIndex && aType.isSubtypeOf(TypesAscending[0]) -> compareBoolean(a, b)
+    aTypeIndex == bTypeIndex && aType.isSubtypeOf(TypesAscending[1]) -> compareNumber(a, b)
+    aTypeIndex == bTypeIndex && bType.isSubtypeOf(TypesAscending[2]) -> compareString(a, b)
+    else -> bTypeIndex - aTypeIndex // Both indices are different
+  }
+}
+
+/**
+ * Indicates that the given type is not supported.
+ *
+ * @param type the unsupported type.
+ */
+private fun badType(
+    type: KType?,
+): Nothing = error("Type $type is not supported in FakeQuery.orderBy yet.")
+
+/**
+ * Returns the first index matching the given predicate, or null.
+ *
+ * @param T the type of the elements of the array.
+ * @return the [Array] for which the predicate is checked.
+ * @param predicate the predicate to check for.
+ * @return the nullable index.
+ */
+private inline fun <T> Array<out T>.indexOfFirstOrNull(predicate: (T) -> Boolean): Int? {
+  val index = indexOfFirst(predicate = predicate)
+  return if (index == -1) null else index
+}
+
+/** Compares the values [a] and [b] as booleans. */
+private fun compareBoolean(a: Any, b: Any): Int {
+  a as Boolean
+  b as Boolean
+  return when {
+    a == b -> Equal
+    a -> SmallestFirst
+    b -> GreatestFirst
+    else -> error("unreachable")
+  }
+}
+
+/** Compares the values [a] and [b] as numbers. */
+private fun compareNumber(a: Any, b: Any): Int {
+  a as Number
+  b as Number
+  return a.toDouble().compareTo(b.toDouble())
+}
+
+/** Compares the values [a] and [b] as strings. */
+private fun compareString(a: Any, b: Any): Int {
+  a as String
+  b as String
+  return a.compareTo(b)
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/OrderByQueryDecorator.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/query/OrderByQueryDecorator.kt
@@ -113,12 +113,7 @@ private inline fun <T> Array<out T>.indexOfFirstOrNull(predicate: (T) -> Boolean
 private fun compareBoolean(a: Any, b: Any): Int {
   a as Boolean
   b as Boolean
-  return when {
-    a == b -> Equal
-    a -> SmallestFirst
-    b -> GreatestFirst
-    else -> error("unreachable")
-  }
+  return a.compareTo(b)
 }
 
 /** Compares the values [a] and [b] as numbers. */

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreQueryTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreQueryTest.kt
@@ -1,5 +1,7 @@
 package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.firestore
 
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.Query.Direction.Ascending
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.Query.Direction.Descending
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.asFlow
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.firestore.FirestoreQuery
 import com.google.common.truth.Truth
@@ -22,6 +24,39 @@ class FirestoreQueryTest {
     every { query.limit(2) } returns result
     reference.limit(2)
     verify { query.limit(2) }
+  }
+
+  @Test
+  fun orderBy_delegatesToOrderByAscending() = runTest {
+    val query = mockk<Query>()
+    val result = mockk<Query>()
+    val reference = FirestoreQuery(query)
+
+    every { query.orderBy("field", Query.Direction.ASCENDING) } returns result
+    reference.orderBy("field")
+    verify { query.orderBy(any<String>(), Query.Direction.ASCENDING) }
+  }
+
+  @Test
+  fun orderByAscending_delegatesToOrderByAscending() = runTest {
+    val query = mockk<Query>()
+    val result = mockk<Query>()
+    val reference = FirestoreQuery(query)
+
+    every { query.orderBy("field", Query.Direction.ASCENDING) } returns result
+    reference.orderBy("field", Ascending)
+    verify { query.orderBy(any<String>(), Query.Direction.ASCENDING) }
+  }
+
+  @Test
+  fun orderByDescending_delegatesToOrderByAscending() = runTest {
+    val query = mockk<Query>()
+    val result = mockk<Query>()
+    val reference = FirestoreQuery(query)
+
+    every { query.orderBy("field", Query.Direction.DESCENDING) } returns result
+    reference.orderBy("field", Descending)
+    verify { query.orderBy(any<String>(), Query.Direction.DESCENDING) }
   }
 
   @Test

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreQueryTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreQueryTest.kt
@@ -60,6 +60,50 @@ class FirestoreQueryTest {
   }
 
   @Test
+  fun whereGreaterThanNotInclusive_delegatesWhereGreaterThan() = runTest {
+    val query = mockk<Query>()
+    val result = mockk<Query>()
+    val reference = FirestoreQuery(query)
+
+    every { query.whereGreaterThan("field", "value") } returns result
+    reference.whereGreaterThan("field", "value", inclusive = false)
+    verify { query.whereGreaterThan("field", "value") }
+  }
+
+  @Test
+  fun whereGreaterThanInclusive_delegatesWhereGreaterThanOrEqual() = runTest {
+    val query = mockk<Query>()
+    val result = mockk<Query>()
+    val reference = FirestoreQuery(query)
+
+    every { query.whereGreaterThanOrEqualTo("field", "value") } returns result
+    reference.whereGreaterThan("field", "value", inclusive = true)
+    verify { query.whereGreaterThanOrEqualTo("field", "value") }
+  }
+
+  @Test
+  fun whereLessThanNotInclusive_delegatesWhereLessThan() = runTest {
+    val query = mockk<Query>()
+    val result = mockk<Query>()
+    val reference = FirestoreQuery(query)
+
+    every { query.whereLessThan("field", "value") } returns result
+    reference.whereLessThan("field", "value", inclusive = false)
+    verify { query.whereLessThan("field", "value") }
+  }
+
+  @Test
+  fun whereLessThanInclusive_delegatesWhereLessThanOrEqual() = runTest {
+    val query = mockk<Query>()
+    val result = mockk<Query>()
+    val reference = FirestoreQuery(query)
+
+    every { query.whereLessThanOrEqualTo("field", "value") } returns result
+    reference.whereLessThan("field", "value", inclusive = true)
+    verify { query.whereLessThanOrEqualTo("field", "value") }
+  }
+
+  @Test
   fun whereEquals_delegatesWhereEqualTo() = runTest {
     val query = mockk<Query>()
     val result = mockk<Query>()

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Query.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Query.kt
@@ -18,6 +18,26 @@ interface Query {
    */
   fun limit(count: Long): Query
 
+  /** An enumeration representing the ordering of some values. */
+  enum class Direction {
+
+    /** A direction which returns the smallest item first. */
+    Ascending,
+
+    /** A direction which returns the greater item first. */
+    Descending,
+  }
+
+  /**
+   * Orders the result according to the values of the document for the given field.
+   *
+   * @param field the field for which the ordering is performed.
+   * @param direction the direction in which the ordering is performed.
+   *
+   * @return the updated [Query].
+   */
+  fun orderBy(field: String, direction: Direction = Direction.Ascending): Query
+
   /**
    * Filters the results by keeping only the documents which contain the given [value] for the given
    * [field].

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Query.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Query.kt
@@ -39,6 +39,30 @@ interface Query {
   fun orderBy(field: String, direction: Direction = Direction.Ascending): Query
 
   /**
+   * Filters the results by keeping only the documents for which the value of the given [field] is
+   * greater than the given [value]. Documents which do not contain this field will be discarded.
+   *
+   * @param field the field which is compared.
+   * @param value the value which is used for comparison.
+   * @param inclusive true if the results should include documents whose field is an exact match.
+   *
+   * @return the updated [Query].
+   */
+  fun whereGreaterThan(field: String, value: Any, inclusive: Boolean = true): Query
+
+  /**
+   * Filters the results by keeping only the documents for which the value of the given [field] is
+   * less than the given [value]. Documents which do not contain this field will be discarded.
+   *
+   * @param field the field which is compared.
+   * @param value the value which is used for comparison.
+   * @param inclusive true if the results should include documents whose field is an exact match.
+   *
+   * @return the updated [Query].
+   */
+  fun whereLessThan(field: String, value: Any, inclusive: Boolean = true): Query
+
+  /**
    * Filters the results by keeping only the documents which contain the given [value] for the given
    * [field].
    *

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreQuery.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreQuery.kt
@@ -29,6 +29,14 @@ class FirestoreQuery(
   override fun orderBy(field: String, direction: Query.Direction): Query =
       FirestoreQuery(reference.orderBy(field, direction.toFirestoreDirection()))
 
+  override fun whereGreaterThan(field: String, value: Any, inclusive: Boolean): Query =
+      if (inclusive) FirestoreQuery(reference.whereGreaterThanOrEqualTo(field, value))
+      else FirestoreQuery(reference.whereGreaterThan(field, value))
+
+  override fun whereLessThan(field: String, value: Any, inclusive: Boolean): Query =
+      if (inclusive) FirestoreQuery(reference.whereLessThanOrEqualTo(field, value))
+      else FirestoreQuery(reference.whereLessThan(field, value))
+
   override fun whereEquals(field: String, value: Any?): Query =
       FirestoreQuery(reference.whereEqualTo(field, value))
 

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreQuery.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreQuery.kt
@@ -20,6 +20,15 @@ class FirestoreQuery(
 
   override fun limit(count: Long): Query = FirestoreQuery(reference.limit(count))
 
+  private fun Query.Direction.toFirestoreDirection(): ActualQuery.Direction =
+      when (this) {
+        Query.Direction.Ascending -> ActualQuery.Direction.ASCENDING
+        Query.Direction.Descending -> ActualQuery.Direction.DESCENDING
+      }
+
+  override fun orderBy(field: String, direction: Query.Direction): Query =
+      FirestoreQuery(reference.orderBy(field, direction.toFirestoreDirection()))
+
   override fun whereEquals(field: String, value: Any?): Query =
       FirestoreQuery(reference.whereEqualTo(field, value))
 


### PR DESCRIPTION
This PR adds support for the `orderBy`, `whereGreaterThan` and `whereLessThan` operators to `Query` (#206). This will be useful when using comparison queries when searching for other players by name.

It contains the following changes :

- Adding a new method `Query.orderBy(field: String, direction: Direction): Query`
  - Implementing `orderBy` for Firestore and testing it
  - Implementing `orderBy` in the `FakeStore` following the Firestore specification and testing it
- Adding a new method `Query.whereLessThan(field: String, value: Any, inclusive: Boolean): Query`
  - Implementing `whereLessThan` for Firestore and testing it
  - Implementing `whereLessThan` in the `FakeStore` following the Firestore specification and testing it
- Adding a new method `Query.whereGreaterThan(field: String, value: Any, inclusive: Boolean): Query`
  - Implementing `whereGreaterThan` for Firestore and testing it
  - Implementing `whereGreaterThan` in the `FakeStore` following the Firestore specification and testing it