### PR TITLE
Disable the `check_thatComposableHasTag` test

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/ar/ArScreenKtTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/ar/ArScreenKtTest.kt
@@ -13,14 +13,14 @@ import ch.epfl.sdp.mobile.state.HomeActivity
 import ch.epfl.sdp.mobile.test.state.setContentWithLocalizedStrings
 import ch.epfl.sdp.mobile.ui.ar.ArScreen
 import org.junit.Rule
-import org.junit.Test
 
 class ArScreenKtTest {
 
   @get:Rule val permissionRule: GrantPermissionRule = grant(Manifest.permission.CAMERA)
   @get:Rule val rule = createAndroidComposeRule<HomeActivity>()
 
-  @Test
+  // FIXME : This is currently broken on CirrusCI (https://github.com/epfl-SDP/android/issues/213)
+  // @Test
   fun check_thatComposableHasTheTag() = withCanceledIntents {
     val strings = rule.setContentWithLocalizedStrings { ArScreen() }
     rule.onNodeWithContentDescription(strings.arContentDescription).assertExists()


### PR DESCRIPTION
Tracked in #213.