### PR TITLE
Change drawing order of available actions on chessboard

### DIFF
--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardModifiers.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardModifiers.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.center
@@ -102,7 +103,7 @@ fun Modifier.actions(
     cells: Int = ChessBoardCells
 ): Modifier = composed {
   val surfaceColor = color.takeOrElse { LocalContentColor.current }
-  cells(positions = positions, cells = cells) {
+  cells(positions = positions, cells = cells, drawBehind = false) {
     drawCircle(color = surfaceColor, radius = diameter.toPx() / 2)
   }
 }
@@ -180,13 +181,17 @@ fun Modifier.selection(
  *
  * @param positions the [Set] of position which should be drawn.
  * @param cells the number of cells which should be displayed per side.
+ * @param drawBehind a [Boolean] which indicates whether the [Modifier] should be drawn behind the
+ * content.
  * @param onDraw the [DrawScope] in which drawing operations should be performed for each cell.
  */
 private fun Modifier.cells(
     positions: Set<ChessBoardState.Position>,
     cells: Int = ChessBoardCells,
+    drawBehind: Boolean = true,
     onDraw: DrawScope.() -> Unit,
-): Modifier = drawBehind {
+): Modifier = drawWithContent {
+  if (!drawBehind) drawContent()
   val origin = size.center - Offset(size.minDimension / 2, size.minDimension / 2)
   val squareSize = size.minDimension / cells
   for ((x, y) in positions) {
@@ -204,4 +209,5 @@ private fun Modifier.cells(
         drawBlock = onDraw,
     )
   }
+  if (drawBehind) drawContent()
 }


### PR DESCRIPTION
This fixes #234 by adding a `drawBehind` parameter to the `Modifier.cells` modifier. When set to `true`, the modifier will behave exactly as before. When set to `false`, the content will be drawn **before** the `Modifier`.

**Tests** : manual visual testing (we don't have screenshot tests yet but this would have been a good candidate)

## Screenshot :

In this situation, the pawn's action to eat the queen is drawn in the right order.

![telegram-cloud-photo-size-4-5947021128218294633-y](https://user-images.githubusercontent.com/6318990/162562706-fd88a766-b843-492d-93c9-f91ab1065441.jpg)
