### PR TITLE
Add `Board.toBoard()` function to flatten boards, and flatten the past board history

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/chess/engine/BoardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/chess/engine/BoardTest.kt
@@ -1,0 +1,28 @@
+package ch.epfl.sdp.mobile.test.application.chess.engine
+
+import ch.epfl.sdp.mobile.application.chess.engine.Position
+import ch.epfl.sdp.mobile.application.chess.engine.implementation.buildBoard
+import ch.epfl.sdp.mobile.application.chess.engine.implementation.emptyBoard
+import ch.epfl.sdp.mobile.application.chess.engine.toBoard
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BoardTest {
+
+  @Test
+  fun given_emptyBoard_when_flattening_then_remainsEqual() {
+    val board = emptyBoard<Nothing>()
+    assertThat(board.toBoard()).isEqualTo(board)
+  }
+
+  @Test
+  fun given_nonEmptyBoard_when_flattening_then_remainsEqual() {
+    val board =
+        buildBoard<Unit> {
+          set(Position(0, 0), Unit)
+          set(Position(1, 1), Unit)
+        }
+
+    assertThat(board.toBoard()).isEqualTo(board)
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/engine/Board.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/engine/Board.kt
@@ -1,5 +1,7 @@
 package ch.epfl.sdp.mobile.application.chess.engine
 
+import ch.epfl.sdp.mobile.application.chess.engine.implementation.buildBoard
+
 /**
  * A [Board] contains a bunch of [Piece] positioned in a certain way.
  *
@@ -28,5 +30,18 @@ interface Board<Piece : Any> : Iterable<Pair<Position, Piece>> {
 
     /** The size of a [Board]. */
     const val Size = 8
+  }
+}
+
+/**
+ * Copies the pieces from this [Board] into a new [Board]. The resulting [Board] is guaranteed to be
+ * immutable, and is created by copying all the pieces from the previous board.
+ *
+ * @param Piece the type of the pieces which are present in a board.
+ * @return a new [Board] copy.
+ */
+fun <Piece : Any> Board<Piece>.toBoard(): Board<Piece> = buildBoard {
+  for ((position, piece) in this@toBoard) {
+    set(position, piece)
   }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/engine/implementation/PersistentGame.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/engine/implementation/PersistentGame.kt
@@ -48,7 +48,7 @@ data class PersistentGame(
           copy(
               previous = this to action,
               nextPlayer = nextPlayer.other(),
-              boards = boards.add(nextBoard),
+              boards = boards.add(nextBoard.toBoard()), // Flatten the Board.
           )
         }
       }


### PR DESCRIPTION
This change dramatically increases the performance of the chess engine, since it ensures that the boards are no longer wrapped in decorators when used in the next game step.

Combined with #236, this makes the game playable when 100+ moves are performed.