### PR TITLE
Remove the legacy `Match()` constructor

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/ChessFacadeTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/ChessFacadeTest.kt
@@ -4,7 +4,6 @@ import ch.epfl.sdp.mobile.application.ChessDocument
 import ch.epfl.sdp.mobile.application.ProfileDocument
 import ch.epfl.sdp.mobile.application.authentication.AuthenticatedUser
 import ch.epfl.sdp.mobile.application.chess.ChessFacade
-import ch.epfl.sdp.mobile.application.chess.Match
 import ch.epfl.sdp.mobile.application.chess.engine.Delta
 import ch.epfl.sdp.mobile.application.chess.engine.Game
 import ch.epfl.sdp.mobile.application.chess.engine.Position
@@ -68,23 +67,6 @@ class ChessFacadeTest {
 
     assertThat(fetchedMatch.white.filterNotNull().first().uid).isEqualTo(user1.uid)
     assertThat(fetchedMatch.black.filterNotNull().first().uid).isEqualTo(user2.uid)
-  }
-
-  @Test
-  fun updatingAMatchWithNoId_doesNothing() = runTest {
-    val auth = mockk<Auth>()
-    val store = emptyStore()
-
-    val chessFacade = ChessFacade(auth, store)
-    // Player 1
-    val user = mockk<AuthenticatedUser>()
-    every { user.uid } returns "userIdWhite"
-
-    val match = Match()
-    match.update(Game.create())
-    val fetchedMatch = chessFacade.matches(user).map { it.firstOrNull() }.first()
-
-    assertThat(fetchedMatch).isEqualTo(null)
   }
 
   @Test

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/Match.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/Match.kt
@@ -3,7 +3,6 @@ package ch.epfl.sdp.mobile.application.chess
 import ch.epfl.sdp.mobile.application.Profile
 import ch.epfl.sdp.mobile.application.chess.engine.Game
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 
 /** Represents a [Game] between two online players */
 interface Match {
@@ -26,13 +25,3 @@ interface Match {
    */
   suspend fun update(game: Game)
 }
-
-/** Creates an empty [Match]. */
-fun Match(): Match =
-    object : Match {
-      override val game = emptyFlow<Game>()
-      override val id: String? = null
-      override val white = emptyFlow<Profile?>()
-      override val black = emptyFlow<Profile?>()
-      override suspend fun update(game: Game) = Unit
-    }


### PR DESCRIPTION
This removes the `Match` builder which has become irrelevant since `StoreMatch` was introduced, and the method `update` was added to `Match`.