### PR TITLE
Fix a MVVM violation in `Person`

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/AuthenticatedUserProfileScreenStateTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/AuthenticatedUserProfileScreenStateTest.kt
@@ -1,5 +1,6 @@
 package ch.epfl.sdp.mobile.test.state
 
+import ch.epfl.sdp.mobile.application.Profile
 import ch.epfl.sdp.mobile.application.authentication.AuthenticatedUser
 import ch.epfl.sdp.mobile.state.AuthenticatedUserProfileScreenState
 import com.google.common.truth.Truth.assertThat
@@ -18,6 +19,7 @@ class AuthenticatedUserProfileScreenStateTest {
     every { mockUser.emoji } returns "test"
     every { mockUser.uid } returns "test"
     every { mockUser.followed } returns false
+    every { mockUser.backgroundColor } returns Profile.Color.Default
 
     val state = AuthenticatedUserProfileScreenState(mockUser)
     assertThat(state.name).isEqualTo("test")

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/profile/ProfileScreenTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/profile/ProfileScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import ch.epfl.sdp.mobile.application.Profile.Color
 import ch.epfl.sdp.mobile.state.ChessMatchAdapter
+import ch.epfl.sdp.mobile.state.toColor
 import ch.epfl.sdp.mobile.test.state.setContentWithLocalizedStrings
 import ch.epfl.sdp.mobile.ui.i18n.LocalizedStrings
 import ch.epfl.sdp.mobile.ui.profile.ProfileScreen
@@ -27,7 +28,7 @@ class ProfileScreenTest {
     override val pastGamesCount = 10
     override fun onChallengeClick() = Unit
     override fun onUnfollowClick() = Unit
-    override val backgroundColor = Color.Default
+    override val backgroundColor = Color.Default.toColor()
     override val name = "Example"
     override val emoji = "🎁"
     override val followed = false

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/setting/SettingScreenTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/setting/SettingScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import ch.epfl.sdp.mobile.application.Profile.Color
 import ch.epfl.sdp.mobile.state.ChessMatchAdapter
+import ch.epfl.sdp.mobile.state.toColor
 import ch.epfl.sdp.mobile.test.state.setContentWithLocalizedStrings
 import ch.epfl.sdp.mobile.ui.i18n.LocalizedStrings
 import ch.epfl.sdp.mobile.ui.setting.SettingScreenState
@@ -28,7 +29,7 @@ class SettingScreenTest {
 
     override fun onEditClick() = Unit
     override fun onSettingsClick() = Unit
-    override val backgroundColor = Color.Default
+    override val backgroundColor = Color.Default.toColor()
     override val name = "Example"
     override val emoji = "🎁"
     override val followed = true

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/social/SocialCardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/social/SocialCardTest.kt
@@ -3,6 +3,7 @@ package ch.epfl.sdp.mobile.test.ui.social
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import ch.epfl.sdp.mobile.application.Profile.Color
+import ch.epfl.sdp.mobile.state.toColor
 import ch.epfl.sdp.mobile.ui.social.Person
 import ch.epfl.sdp.mobile.ui.social.PersonItem
 import org.junit.Rule
@@ -12,7 +13,7 @@ class SocialCardTest {
   @get:Rule val rule = createComposeRule()
 
   private class FakeFriendCard : Person {
-    override val backgroundColor: Color = Color.Default
+    override val backgroundColor = Color.Default.toColor()
     override val name: String = "Toto"
     override val emoji: String = ":3"
     override val followed: Boolean = false

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/social/SocialScreenTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/social/SocialScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import ch.epfl.sdp.mobile.application.Profile.Color
+import ch.epfl.sdp.mobile.state.toColor
 import ch.epfl.sdp.mobile.test.state.setContentWithLocalizedStrings
 import ch.epfl.sdp.mobile.ui.i18n.English.socialPerformFollow
 import ch.epfl.sdp.mobile.ui.i18n.English.socialSearchEmptyTitle
@@ -29,7 +30,7 @@ private val People =
 
 private fun createPerson(bgColor: Color, name: String, emoji: String): Person {
   return object : Person {
-    override val backgroundColor: Color = bgColor
+    override val backgroundColor = bgColor.toColor()
     override val name: String = name
     override val emoji: String = emoji
     override val followed = false
@@ -119,7 +120,7 @@ class SocialScreenTest {
           SearchResultList(
               listOf(
                   object : Person {
-                    override val backgroundColor = Color.Default
+                    override val backgroundColor = Color.Default.toColor()
                     override val name = "test"
                     override val emoji = ":)"
                     override val followed = false

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulFollowingScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulFollowingScreen.kt
@@ -27,7 +27,7 @@ data class ProfileAdapter(
     val profile: Profile,
 ) : Person {
   val uid = profile.uid
-  override val backgroundColor = profile.backgroundColor
+  override val backgroundColor = profile.backgroundColor.toColor()
   override val name = profile.name
   override val emoji = profile.emoji
   override val followed = profile.followed

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulProfileScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulProfileScreen.kt
@@ -9,21 +9,19 @@ import ch.epfl.sdp.mobile.application.Profile
 import ch.epfl.sdp.mobile.ui.profile.ProfileScreen
 import ch.epfl.sdp.mobile.ui.profile.ProfileScreenState
 import ch.epfl.sdp.mobile.ui.social.ChessMatch
+import ch.epfl.sdp.mobile.ui.social.Person
 
 class FetchedUserProfileScreenState(
     user: Profile,
-) : ProfileScreenState {
+) : ProfileScreenState, Person by ProfileAdapter(user) {
   override val email = ""
   override val pastGamesCount = 0
   override val matches = emptyList<ChessMatch>()
-  override val backgroundColor = user.backgroundColor
-  override val name = user.name
-  override val emoji = user.emoji
-  override val followed = user.followed
 
   override fun onUnfollowClick() {}
   override fun onChallengeClick() {}
 }
+
 /**
  * A stateful composable to visit the profile page of other players
  *

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulSettingsScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulSettingsScreen.kt
@@ -3,22 +3,19 @@ package ch.epfl.sdp.mobile.state
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import ch.epfl.sdp.mobile.application.Profile.Color
 import ch.epfl.sdp.mobile.application.authentication.AuthenticatedUser
 import ch.epfl.sdp.mobile.ui.setting.SettingScreenState
 import ch.epfl.sdp.mobile.ui.setting.SettingsScreen
 import ch.epfl.sdp.mobile.ui.social.ChessMatch
+import ch.epfl.sdp.mobile.ui.social.Person
 
-class AuthenticatedUserProfileScreenState(private val user: AuthenticatedUser) :
-    SettingScreenState {
+class AuthenticatedUserProfileScreenState(
+    private val user: AuthenticatedUser,
+) : SettingScreenState, Person by ProfileAdapter(user) {
   override val email = user.email
   override val pastGamesCount = 0
   override val puzzlesCount = 0
   override val matches = emptyList<ChessMatch>()
-  override val backgroundColor = Color.Orange
-  override val name = user.name
-  override val emoji = user.emoji
-  override val followed = user.followed
 
   override fun onSettingsClick() {}
   override fun onEditClick() {}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/prepare_game/OpponentList.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/prepare_game/OpponentList.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.unit.dp
-import ch.epfl.sdp.mobile.state.toColor
 import ch.epfl.sdp.mobile.ui.social.Person
 
 /**
@@ -83,8 +82,7 @@ private fun <P : Person> Opponent(
       modifier = modifier,
   ) {
     Box(
-        modifier =
-            Modifier.size(40.dp).clip(CircleShape).background(person.backgroundColor.toColor()),
+        modifier = Modifier.size(40.dp).clip(CircleShape).background(person.backgroundColor),
     ) { Text(person.emoji, modifier = Modifier.align(Alignment.Center)) }
     Spacer(modifier = Modifier.width(16.dp))
     Text(

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import ch.epfl.sdp.mobile.state.LocalLocalizedStrings
-import ch.epfl.sdp.mobile.state.toColor
 
 /**
  * Main component of the ProfileScreen that groups ProfileHeader and list of Matches
@@ -91,7 +90,7 @@ fun ProfilePicture(
     modifier: Modifier = Modifier,
 ) {
   Box(
-      modifier = modifier.size(118.dp).background(state.backgroundColor.toColor(), CircleShape),
+      modifier = modifier.size(118.dp).background(state.backgroundColor, CircleShape),
       contentAlignment = Alignment.Center,
   ) { Text(state.emoji, style = MaterialTheme.typography.h3) }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/setting/SettingScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/setting/SettingScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.dp
 import ch.epfl.sdp.mobile.state.LocalLocalizedStrings
-import ch.epfl.sdp.mobile.state.toColor
 import ch.epfl.sdp.mobile.ui.profile.SettingTabBar
 import ch.epfl.sdp.mobile.ui.profile.UserScreen
 import ch.epfl.sdp.mobile.ui.profile.rememberSettingTabBarState
@@ -94,7 +93,7 @@ fun SettingPicture(
 ) {
   val strings = LocalLocalizedStrings.current
   Box(
-      modifier = modifier.size(118.dp).background(state.backgroundColor.toColor(), CircleShape),
+      modifier = modifier.size(118.dp).background(state.backgroundColor, CircleShape),
       contentAlignment = Alignment.Center,
   ) {
     Text(state.emoji, style = MaterialTheme.typography.h3)

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/social/Person.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/social/Person.kt
@@ -1,6 +1,6 @@
 package ch.epfl.sdp.mobile.ui.social
 
-import ch.epfl.sdp.mobile.application.Profile.Color
+import androidx.compose.ui.graphics.Color
 
 /** An interface representing a list of people you're following. */
 interface Person {

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/social/PersonItem.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/social/PersonItem.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import ch.epfl.sdp.mobile.state.toColor
 
 /**
  * This list item is used to display player information in the Social screen.
@@ -34,8 +33,7 @@ fun PersonItem(
       modifier = modifier,
       icon = {
         Box(
-            modifier =
-                Modifier.size(40.dp).clip(CircleShape).background(person.backgroundColor.toColor()),
+            modifier = Modifier.size(40.dp).clip(CircleShape).background(person.backgroundColor),
         ) { Text(person.emoji, modifier = Modifier.align(Alignment.Center)) }
       },
       text = {


### PR DESCRIPTION
The `backgroundColor` property of `Person` is a `ch.epfl.sdp.mobile.application.Profile.Color`, which is a model concept. This PR changes its type to `androidx.compose.ui.graphics.Color`, since `Person` is part of the view.