### PR TITLE
Fix AR promotion and improve piece loading

### DIFF
--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ChessScene.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ChessScene.kt
@@ -8,16 +8,23 @@ import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Color.*
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Position
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Rank
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState.Rank.*
+import com.google.android.filament.Box
+import com.google.ar.sceneform.rendering.Renderable
 import com.google.ar.sceneform.rendering.RenderableInstance
 import io.github.sceneview.ar.node.ArModelNode
 import io.github.sceneview.ar.node.PlacementMode
 import io.github.sceneview.material.setBaseColor
 import io.github.sceneview.math.Position as ArPosition
 import io.github.sceneview.math.Rotation
+import io.github.sceneview.model.GLBLoader
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.utils.Color as ArColor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.onEach
 
 /**
  * This class represent the AR chess scene which contains :
@@ -33,36 +40,47 @@ class ChessScene<Piece : ChessBoardState.Piece>(
     scope: CoroutineScope,
     startingBoard: Map<Position, Piece>,
 ) {
-  val boardNode: ArModelNode = ArModelNode(placementMode = PlacementMode.PLANE_HORIZONTAL)
 
-  private var currentPosition: Map<Position, Piece> = emptyMap()
-  private var currentPieces: MutableMap<Piece, ModelNode> = mutableMapOf()
+  /** The [ArModelNode] which acts as the root of the [ArModelNode] hierarchy. */
+  val boardNode = ArModelNode(placementMode = PlacementMode.PLANE_HORIZONTAL)
 
-  private var boardHeight: Float = 0f
-  private var boardHalfSize: Float = 0f
-
-  private var isLoaded = false
+  /** A conflated [Channel] which associates the position of the pieces to their values. */
+  private val currentPositionChannel =
+      Channel<Map<Position, Piece>>(capacity = CONFLATED).apply { trySend(startingBoard) }
 
   init {
     scope.launch {
+
       // Load Board
-      val renderableInstance = loadBoard() ?: return@launch
+      val boardRenderableInstance = prepareBoardRenderableInstance(boardNode) ?: return@launch
+      val boundingBox = boardRenderableInstance.filamentAsset?.boundingBox ?: return@launch
+      val pieceRenderable = loadPieceRenderable()
 
-      // Once loaded compute the board size
-      val filamentAsset = renderableInstance.filamentAsset ?: return@launch
-      val boardBoundingBox = filamentAsset.boundingBox
+      currentPositionChannel
+          .consumeAsFlow()
+          .onEach { positions ->
 
-      // Get height (on y axe) of the board
-      // Double the value to get the total height of the box
-      boardHeight = 2 * boardBoundingBox.halfExtent[1]
-      boardHalfSize = boardBoundingBox.halfExtent[0]
+            // Remove all current children.
+            boardNode.children.forEach {
+              val child = boardNode.removeChild(it)
+              child.destroy()
+            }
 
-      // Load pieces
-      loadPieces(startingBoard)
-      isLoaded = true
-
-      // Move the pieces to the correct position
-      moveAllPiece()
+            // Add all the pieces at the appropriate position.
+            for ((position, piece) in positions) {
+              val arPosition = toArPosition(position, boundingBox)
+              with(ModelNode(position = arPosition)) {
+                val renderable = setModel(pieceRenderable(piece.rank)) ?: return@with
+                // Rotate the black pieces to face the right direction.
+                if (piece.color == Black) {
+                  modelRotation = Rotation(0f, 180f, 0f)
+                  renderable.material.filamentMaterialInstance.setBaseColor(piece.color.colorVector)
+                }
+                boardNode.addChild(this)
+              }
+            }
+          }
+          .collect()
     }
   }
 
@@ -72,90 +90,47 @@ class ChessScene<Piece : ChessBoardState.Piece>(
    * @param pieces The new piece position
    */
   fun update(pieces: Map<Position, Piece>) {
-    savePosition(pieces)
-    moveAllPiece()
+    currentPositionChannel.trySend(pieces)
   }
 
   /**
-   * Save the newest pieces position
+   * Prepares the [ArModelNode] which contains the AR board to be displayed, by loading the
+   * appropriate model.
    *
-   * @param pieces The new pieces position to save
+   * @param node the [ArModelNode] to bee prepared.
+   * @return the [RenderableInstance] which can be used to manipulate the loaded model.
    */
-  private fun savePosition(pieces: Map<Position, Piece>) {
-    currentPosition = pieces
-  }
+  private suspend fun prepareBoardRenderableInstance(node: ArModelNode): RenderableInstance? =
+      node.loadModel(
+          context = context,
+          glbFileLocation = ChessModels.Board,
+          autoScale = true,
+      )
 
-  /** Move all pieces */
-  private fun moveAllPiece() {
-    if (isLoaded) {
-      for ((position, piece) in currentPosition) {
-        move(piece, position)
-      }
+  /**
+   * Loads all the [Renderable] for any [Rank] and makes them available as a higher-order function.
+   * All the models will be loaded in parallel.
+   *
+   * @return a higher-order function which maps ranks and colors to the right [Renderable].
+   */
+  private suspend fun loadPieceRenderable(): (Rank) -> Renderable = coroutineScope {
+    val loaded = mutableMapOf<Rank, Renderable>()
+    for (rank in Rank.values()) {
+      launch { loaded[rank] = loadPieceRenderable(rank) }
     }
-  }
-
-  /** Move the given [piece] at a specific [position]] */
-  private fun move(piece: Piece, position: Position) {
-    val model = currentPieces[piece] ?: return
-    model.position = toArPosition(position)
+    { rank -> requireNotNull(loaded[rank]) }
   }
 
   /**
-   * Load the board model
+   * Loads the [Renderable] for the given [Rank] and [Color]. This [Renderable] may then be used
+   * across multiple nodes to be rendered on the chess board.
    *
-   * @return The [RenderableInstance] that can be used to manipulate the loaded model
+   * @param rank the [Rank] of the piece to fetch.
+   * @return the [Renderable] to be displayed.
    */
-  private suspend fun loadBoard(): RenderableInstance? {
-    return boardNode.loadModel(
-        context = context,
-        glbFileLocation = ChessModels.Board,
-        autoScale = true,
-    )
-  }
-
-  /**
-   * Load a chess [piece] and place it to a given [position] relative to the parent (aka the
-   * chessboard)
-   */
-  private suspend fun loadPieceModel(
-      piece: Piece,
-      position: Position,
-  ): ModelNode {
-    val path = piece.rank.arModelPath
-
-    val model =
-        ModelNode(position = toArPosition(position)).apply {
-          // Load the piece
-          loadModel(context = context, glbFileLocation = path)
-
-          // Rotate the black knight to be faced inside the board
-          if (piece.rank == Knight && piece.color == Black) {
-            modelRotation = Rotation(0f, 180f, 0f)
-          }
-        }
-
-    val renderableInstance = model.modelInstance ?: return model
-
-    // Once loaded change the piece appearance
-    val color = piece.color.colorVector
-    renderableInstance.material.filamentMaterialInstance.setBaseColor(color)
-
-    return model
-  }
-
-  /**
-   * Load model for the given pieces list
-   *
-   * @param pieces The pieces that need to be load
-   */
-  private suspend fun loadPieces(pieces: Map<Position, Piece>) {
-    for ((position, piece) in pieces) {
-      val model = loadPieceModel(piece, position)
-      // Add the new model node to the board
-      boardNode.addChild(model)
-      currentPieces[piece] = model
-    }
-  }
+  private suspend fun loadPieceRenderable(
+      rank: Rank,
+  ): Renderable = requireNotNull(GLBLoader.loadModel(context, rank.arModelPath))
 
   /** Scale the whole scene with the given [value] */
   internal fun scale(value: Float) {
@@ -164,38 +139,49 @@ class ChessScene<Piece : ChessBoardState.Piece>(
 
   companion object {
     // This value cannot be computed, it's chosen by guess
-    private const val BoardBorderSize = 2.2f
+    const val BoardBorderSize = 2.2f
   }
-
-  /** For the given [Position] and transform it into AR board [ArPosition] */
-  private fun toArPosition(position: Position): ArPosition {
-
-    val cellSize = (boardHalfSize - BoardBorderSize) / 4
-    val cellCenter = cellSize / 2
-
-    fun transform(value: Int): Float {
-      return -boardHalfSize + BoardBorderSize + value * cellSize + cellCenter
-    }
-    return ArPosition(x = transform(position.x), y = boardHeight, z = transform(position.y))
-  }
-
-  /** Transform a [Rank] into the corresponding model's path */
-  private val Rank.arModelPath: String
-    get() =
-        when (this) {
-          King -> ChessModels.King
-          Bishop -> ChessModels.Bishop
-          Pawn -> ChessModels.Pawn
-          Knight -> ChessModels.Knight
-          Queen -> ChessModels.Queen
-          Rook -> ChessModels.Rook
-        }
-
-  /** Convert the [Color] into a color that can be used by the AR renderer */
-  private val Color.colorVector: ArColor
-    get() =
-        when (this) {
-          Black -> PawniesArColors.Black
-          White -> PawniesArColors.White
-        }
 }
+
+/**
+ * For the given [Position] and transform it into AR board [ArPosition].
+ *
+ * @param position the [Position] which should be mapped to an [ArPosition].
+ * @param boundingBox the [Box] of the board in which the cells are to be placed.
+ */
+private fun toArPosition(
+    position: Position,
+    boundingBox: Box,
+): ArPosition {
+
+  val boardHeight = 2 * boundingBox.halfExtent[1]
+  val boardHalfSize = boundingBox.halfExtent[0]
+
+  val cellSize = (boardHalfSize - ChessScene.BoardBorderSize) / 4
+  val cellCenter = cellSize / 2
+
+  fun transform(value: Int): Float {
+    return -boardHalfSize + ChessScene.BoardBorderSize + value * cellSize + cellCenter
+  }
+  return ArPosition(x = transform(position.x), y = boardHeight, z = transform(position.y))
+}
+
+/** Transform a [Rank] into the corresponding model's path */
+private val Rank.arModelPath: String
+  get() =
+      when (this) {
+        King -> ChessModels.King
+        Bishop -> ChessModels.Bishop
+        Pawn -> ChessModels.Pawn
+        Knight -> ChessModels.Knight
+        Queen -> ChessModels.Queen
+        Rook -> ChessModels.Rook
+      }
+
+/** Convert the [Color] into a color that can be used by the AR renderer */
+private val Color.colorVector: ArColor
+  get() =
+      when (this) {
+        Black -> PawniesArColors.Black
+        White -> PawniesArColors.White
+      }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ChessScene.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ChessScene.kt
@@ -97,7 +97,7 @@ class ChessScene<Piece : ChessBoardState.Piece>(
    * Prepares the [ArModelNode] which contains the AR board to be displayed, by loading the
    * appropriate model.
    *
-   * @param node the [ArModelNode] to bee prepared.
+   * @param node the [ArModelNode] to be prepared.
    * @return the [RenderableInstance] which can be used to manipulate the loaded model.
    */
   private suspend fun prepareBoardRenderableInstance(node: ArModelNode): RenderableInstance? =

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ChessScene.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ChessScene.kt
@@ -74,8 +74,8 @@ class ChessScene<Piece : ChessBoardState.Piece>(
                 // Rotate the black pieces to face the right direction.
                 if (piece.color == Black) {
                   modelRotation = Rotation(0f, 180f, 0f)
-                  renderable.material.filamentMaterialInstance.setBaseColor(piece.color.colorVector)
                 }
+                renderable.material.filamentMaterialInstance.setBaseColor(piece.color.colorVector)
                 boardNode.addChild(this)
               }
             }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ChessScene.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ChessScene.kt
@@ -111,7 +111,7 @@ class ChessScene<Piece : ChessBoardState.Piece>(
    * Loads all the [Renderable] for any [Rank] and makes them available as a higher-order function.
    * All the models will be loaded in parallel.
    *
-   * @return a higher-order function which maps ranks and colors to the right [Renderable].
+   * @return a higher-order function which maps ranks to the right [Renderable].
    */
   private suspend fun loadPieceRenderable(): (Rank) -> Renderable = coroutineScope {
     val loaded = mutableMapOf<Rank, Renderable>()


### PR DESCRIPTION
This PR fixes some small issues from #278. The public API of `ChessScene` remains untouched.

## Notable changes / fixes

- A race condition with the `startingBoard` which could be read and applied **after** a subsequent call to `update` is fixed (by using a conflated `Channel` and consuming it as a flow); and
- The promoted pieces are now displayed because piece nodes are created dynamically (as they should be).
