### PR TITLE
Add a `Badge` composable

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/tournaments/BadgeTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/tournaments/BadgeTest.kt
@@ -1,0 +1,76 @@
+package ch.epfl.sdp.mobile.test.ui.tournaments
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import ch.epfl.sdp.mobile.test.state.setContentWithLocalizedStrings
+import ch.epfl.sdp.mobile.ui.tournaments.Badge
+import ch.epfl.sdp.mobile.ui.tournaments.BadgeType
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.channels.Channel
+import org.junit.Rule
+import org.junit.Test
+
+class BadgeTest {
+
+  @get:Rule val rule = createComposeRule()
+
+  @Test
+  fun given_joinBadge_when_displayed_then_showsCorrectText() {
+    val strings = rule.setContentWithLocalizedStrings { Badge(BadgeType.Join, onClick = {}) }
+    rule.onNodeWithText(strings.tournamentsBadgeJoin).assertIsDisplayed()
+  }
+
+  @Test
+  fun given_participantBadge_when_displayed_then_showsCorrectText() {
+    val strings = rule.setContentWithLocalizedStrings { Badge(BadgeType.Participant, onClick = {}) }
+    rule.onNodeWithText(strings.tournamentsBadgeParticipant).assertIsDisplayed()
+  }
+
+  @Test
+  fun given_adminBadge_when_displayed_then_showsCorrectText() {
+    val strings = rule.setContentWithLocalizedStrings { Badge(BadgeType.Admin, onClick = {}) }
+    rule.onNodeWithText(strings.tournamentsBadgeAdmin).assertIsDisplayed()
+  }
+
+  @Test
+  fun given_enabledBadge_when_clicking_then_callsCallback() {
+    val channel = Channel<Unit>(1)
+    val strings =
+        rule.setContentWithLocalizedStrings {
+          Badge(
+              BadgeType.Admin,
+              onClick = {
+                channel.trySend(Unit)
+                channel.close()
+              },
+          )
+        }
+    rule.onNodeWithText(strings.tournamentsBadgeAdmin).performClick()
+    assertThat(channel.tryReceive().getOrNull()).isEqualTo(Unit)
+    assertThat(channel.tryReceive().isClosed).isTrue()
+  }
+
+  @Test
+  fun given_disabled_when_clicking_then_doesNotCallCallback() {
+    val channel = Channel<Unit>(1)
+    val strings =
+        rule.setContentWithLocalizedStrings {
+          Badge(BadgeType.Admin, onClick = { channel.trySend(Unit) }, enabled = false)
+        }
+    rule.onNodeWithText(strings.tournamentsBadgeAdmin).performClick()
+    assertThat(channel.tryReceive().isSuccess).isFalse()
+  }
+
+  @Test
+  fun given_badge_when_changingType_then_displaysRightText() {
+    var type by mutableStateOf(BadgeType.Admin)
+    val strings = rule.setContentWithLocalizedStrings { Badge(type, onClick = {}) }
+    type = BadgeType.Join
+    rule.onNodeWithText(strings.tournamentsBadgeJoin).assertIsDisplayed()
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/i18n/English.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/i18n/English.kt
@@ -100,4 +100,8 @@ object English : LocalizedStrings {
   override val prepareGamePlayOnline = "Online".uppercase()
 
   override val playOnlineGames = "Online games"
+
+  override val tournamentsBadgeJoin = "Join"
+  override val tournamentsBadgeParticipant = "Participant"
+  override val tournamentsBadgeAdmin = "Admin"
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/i18n/LocalizedStrings.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/i18n/LocalizedStrings.kt
@@ -102,4 +102,8 @@ interface LocalizedStrings {
   val prepareGamePlayOnline: String
 
   val playOnlineGames: String
+
+  val tournamentsBadgeJoin: String
+  val tournamentsBadgeParticipant: String
+  val tournamentsBadgeAdmin: String
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/Badge.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/Badge.kt
@@ -1,0 +1,118 @@
+package ch.epfl.sdp.mobile.ui.tournaments
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.with
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import ch.epfl.sdp.mobile.state.LocalLocalizedStrings
+import ch.epfl.sdp.mobile.ui.*
+import ch.epfl.sdp.mobile.ui.tournaments.BadgeType.*
+
+/** The type of the badge. */
+enum class BadgeType {
+
+  /** Indicates that this tournament can be joined. */
+  Join,
+
+  /** Indicates that we participate in this tournament. */
+  Participant,
+
+  /** Indicates that we administer this tournament. */
+  Admin,
+}
+
+/**
+ * A badge which represents whether the user may join an existing tournament, or if they're already
+ * included as a participant or administrator in it.
+ *
+ * @param type the [BadgeType] for this badge.
+ * @param onClick the callback which is called when the user clicks.
+ * @param modifier the [Modifier] for this composable.
+ * @param enabled true if the [Badge] may be clicked, false otherwise.
+ */
+@Composable
+fun Badge(
+    type: BadgeType,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+  val currentType = rememberUpdatedState(type)
+  val colors = remember(currentType) { BadgeColors(currentType) }
+  Button(
+      onClick = onClick,
+      modifier = modifier.heightIn(min = 32.dp),
+      colors = colors,
+      enabled = enabled,
+      elevation = null,
+      border = BorderStroke(2.dp, PawniesColors.Green500),
+      shape = CircleShape,
+      contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
+  ) {
+    ProvideTextStyle(MaterialTheme.typography.subtitle1) {
+      AnimatedContent(
+          targetState = type,
+          transitionSpec = {
+            FadeEnterTransition with FadeExitTransition using SizeTransform(clip = false)
+          },
+      ) { current -> BadgeContent(current) }
+    }
+  }
+}
+
+/**
+ * The content of the badge which displays the status.
+ *
+ * @param type the type of the badge.
+ * @param modifier the [Modifier] for this badge.
+ */
+@Composable
+private fun BadgeContent(
+    type: BadgeType,
+    modifier: Modifier = Modifier,
+) {
+  val strings = LocalLocalizedStrings.current
+  when (type) {
+    Join ->
+        Row(modifier, spacedBy(8.dp), CenterVertically) {
+          Icon(PawniesIcons.Add, null)
+          Text(strings.tournamentsBadgeJoin)
+        }
+    Participant -> Text(strings.tournamentsBadgeParticipant, modifier)
+    Admin -> Text(strings.tournamentsBadgeAdmin, modifier)
+  }
+}
+
+/**
+ * The [ButtonColors] which should be applied to the [Badge].
+ *
+ * @param type the current type of the badge.
+ */
+private class BadgeColors(type: State<BadgeType>) : ButtonColors {
+
+  /** The current [BadgeType]. */
+  private val type by type
+
+  /** Returns the background color. */
+  private fun background(): Color =
+      when (type) {
+        Join, Participant -> PawniesColors.Green100.copy(alpha = 0f)
+        Admin -> PawniesColors.Green100
+      }
+
+  /** Returns the foreground color. */
+  private fun content(): Color = PawniesColors.Green500
+
+  @Composable override fun backgroundColor(enabled: Boolean) = animateColorAsState(background())
+  @Composable override fun contentColor(enabled: Boolean) = animateColorAsState(content())
+}


### PR DESCRIPTION
This PR implements the following Badge from the Figma mockups :

<img width="520" alt="image" src="https://user-images.githubusercontent.com/6318990/167165492-9184b6c6-070d-4178-96eb-31c32c0dddb4.png">

It is part of #292.
