### PR TITLE
Add `Transaction` support to `FirestoreStore` and `FakeStore`

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/DslTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/DslTest.kt
@@ -1,6 +1,7 @@
 package ch.epfl.sdp.mobile.test.infrastructure.persistence.store
 
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.asFlow
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.get
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.set
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.filter
@@ -196,5 +197,18 @@ class DslTest {
     val store = emptyStore()
     val reference = store.collection("col").document("id")
     assertThat(reference.id).isEqualTo("id")
+  }
+
+  @Test
+  fun given_document_when_readingThenSettingInTransaction_then_succeeds() = runTest {
+    val store = buildStore { collection("users") { document("alexandre", alexandre) } }
+    store.transaction {
+      val document = get<User>(store.collection("users").document("alexandre"))
+      if (document != null) {
+        set(store.collection("users").document("matthieu"), document)
+      }
+    }
+    val fetched = store.collection("users").document("matthieu").asFlow<User>().first()
+    assertThat(fetched).isEqualTo(alexandre)
   }
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentReference.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeDocumentReference.kt
@@ -1,6 +1,5 @@
 package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake
 
-import ch.epfl.sdp.mobile.infrastructure.persistence.store.CollectionReference
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentEditScope
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentReference
 import ch.epfl.sdp.mobile.test.getOrPut
@@ -26,29 +25,44 @@ class FakeDocumentReference(id: FakeDocumentId) : DocumentReference, CollectionB
   override val id: String
     get() = state.value.id.value
 
-  override fun collection(path: String): CollectionReference {
+  override fun collection(path: String): FakeCollectionReference {
     return state.updateAndGetWithValue {
       val (col, ref) = it.collections.getOrPut(path) { FakeCollectionReference() }
       it.copy(collections = col) to ref
     }
   }
 
+  /** @see get */
+  fun atomicGet(): FakeDocumentSnapshot {
+    val value = state.value
+    return FakeDocumentSnapshot(value.id, value.record)
+  }
+
+  /** @see delete */
+  fun atomicDelete() = state.update { it.copy(record = null) }
+
+  /** @see set */
+  fun atomicSet(scope: DocumentEditScope.() -> Unit) =
+      state.update { it.copy(record = FakeDocumentRecord().update(scope)) }
+
+  /** @see set */
+  fun <T : Any> atomicSet(value: T, valueClass: KClass<T>) =
+      state.update { it.copy(record = FakeDocumentRecord.fromObject(value, valueClass)) }
+
+  /** @see update */
+  fun atomicUpdate(scope: DocumentEditScope.() -> Unit) =
+      state.update { it.copy(record = (it.record ?: FakeDocumentRecord()).update(scope)) }
+
   override fun asDocumentSnapshotFlow(): Flow<FakeDocumentSnapshot?> =
       state.map { FakeDocumentSnapshot(it.id, it.record) }
 
-  override suspend fun delete() = state.update { it.copy(record = null) }
+  override suspend fun delete() = atomicDelete()
 
-  override suspend fun set(scope: DocumentEditScope.() -> Unit) {
-    state.update { it.copy(record = FakeDocumentRecord().update(scope)) }
-  }
+  override suspend fun set(scope: DocumentEditScope.() -> Unit) = atomicSet(scope)
 
-  override suspend fun <T : Any> set(value: T, valueClass: KClass<T>) {
-    state.update { it.copy(record = FakeDocumentRecord.fromObject(value, valueClass)) }
-  }
+  override suspend fun <T : Any> set(value: T, valueClass: KClass<T>) = atomicSet(value, valueClass)
 
-  override suspend fun update(scope: DocumentEditScope.() -> Unit) {
-    state.update { it.copy(record = (it.record ?: FakeDocumentRecord()).update(scope)) }
-  }
+  override suspend fun update(scope: DocumentEditScope.() -> Unit) = atomicUpdate(scope)
 
   override fun collection(path: String, content: DocumentBuilder.() -> Unit) =
       state

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeStore.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeStore.kt
@@ -1,7 +1,9 @@
 package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake
 
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.CollectionReference
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentReference
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.Store
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.Transaction
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.store.CollectionBuilder
 
 /**
@@ -19,4 +21,8 @@ private constructor(
   constructor() : this(FakeDocumentReference(FakeDocumentId.Root))
 
   override fun collection(path: String): CollectionReference = root.collection(path)
+
+  override suspend fun <R> transaction(
+      block: Transaction<DocumentReference>.() -> R,
+  ): R = block(FakeTransaction())
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeTransaction.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/fake/FakeTransaction.kt
@@ -1,0 +1,38 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.fake
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentEditScope
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentSnapshot
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.Transaction
+import kotlin.reflect.KClass
+
+/**
+ * An implementation of [Transaction] that supports [FakeDocumentReference]. It does not offer true
+ * transaction semantics, however these aren't really needed in the context of our unit tests and
+ * would be out of scope for the [FakeStore].
+ */
+class FakeTransaction : Transaction<FakeDocumentReference> {
+
+  override fun set(
+      reference: FakeDocumentReference,
+      scope: DocumentEditScope.() -> Unit,
+  ) = reference.atomicSet(scope)
+
+  override fun <T : Any> set(
+      reference: FakeDocumentReference,
+      value: T,
+      valueClass: KClass<T>,
+  ) = reference.atomicSet(value, valueClass)
+
+  override fun update(
+      reference: FakeDocumentReference,
+      scope: DocumentEditScope.() -> Unit,
+  ) = reference.atomicUpdate(scope)
+
+  override fun delete(
+      reference: FakeDocumentReference,
+  ) = reference.atomicDelete()
+
+  override fun getSnapshot(
+      reference: FakeDocumentReference,
+  ): DocumentSnapshot = reference.atomicGet()
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreTransactionTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/store/firestore/FirestoreTransactionTest.kt
@@ -1,0 +1,96 @@
+package ch.epfl.sdp.mobile.test.infrastructure.persistence.store.firestore
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.firestore.FirestoreDocumentReference
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.firestore.FirestoreTransaction
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.get
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.set
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.firestore.DocumentReference as ActualDocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.Transaction as ActualTransaction
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class FirestoreTransactionTest {
+
+  @Test
+  fun given_transaction_when_set_then_callsFirestoreMethod() {
+    val actualTransaction = mockk<ActualTransaction>()
+    val actualReference = mockk<ActualDocumentReference>()
+    val transaction = FirestoreTransaction(actualTransaction)
+    val reference = FirestoreDocumentReference(actualReference)
+
+    every { actualTransaction.set(actualReference, mapOf("hello" to "world")) } returns
+        actualTransaction
+
+    transaction.set(reference) { this["hello"] = "world" }
+
+    verify { actualTransaction.set(actualReference, mapOf("hello" to "world")) }
+  }
+
+  @Test
+  fun given_transaction_when_setGeneric_then_callsFirestoreMethod() {
+    val actualTransaction = mockk<ActualTransaction>()
+    val actualReference = mockk<ActualDocumentReference>()
+    val transaction = FirestoreTransaction(actualTransaction)
+    val reference = FirestoreDocumentReference(actualReference)
+
+    every { actualTransaction.set(actualReference, any()) } returns actualTransaction
+
+    transaction.set(reference, Any())
+
+    verify { actualTransaction.set(actualReference, any()) }
+  }
+
+  @Test
+  fun given_transaction_when_update_then_callsFirestoreMethod() {
+    val actualTransaction = mockk<ActualTransaction>()
+    val actualReference = mockk<ActualDocumentReference>()
+    val transaction = FirestoreTransaction(actualTransaction)
+    val reference = FirestoreDocumentReference(actualReference)
+
+    every {
+      actualTransaction.set(actualReference, mapOf("hello" to "world"), SetOptions.merge())
+    } returns actualTransaction
+
+    transaction.update(reference) { set("hello", "world") }
+
+    verify { actualTransaction.set(actualReference, mapOf("hello" to "world"), SetOptions.merge()) }
+  }
+
+  @Test
+  fun given_transaction_when_delete_then_callsFirestoreMethod() {
+    val actualTransaction = mockk<ActualTransaction>()
+    val actualReference = mockk<ActualDocumentReference>()
+    val transaction = FirestoreTransaction(actualTransaction)
+    val reference = FirestoreDocumentReference(actualReference)
+
+    every { actualTransaction.delete(actualReference) } returns actualTransaction
+
+    transaction.delete(reference)
+
+    verify { actualTransaction.delete(actualReference) }
+  }
+
+  @Test
+  fun given_transaction_when_getGeneric_then_callsFirestoreMethod() {
+    val actualTransaction = mockk<ActualTransaction>()
+    val actualReference = mockk<ActualDocumentReference>()
+    val actualSnapshot = mockk<DocumentSnapshot>()
+    val transaction = FirestoreTransaction(actualTransaction)
+    val reference = FirestoreDocumentReference(actualReference)
+
+    val result = emptyMap<Nothing, Nothing>()
+
+    every { actualTransaction.get(actualReference) } returns actualSnapshot
+    every { actualSnapshot.toObject<Map<*, *>>(any()) } returns result
+
+    assertThat(transaction.get<Map<Nothing, Nothing>>(reference)).isEqualTo(result)
+
+    verify { actualTransaction.get(actualReference) }
+    verify { actualSnapshot.toObject<Map<*, *>>(any()) }
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Store.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Store.kt
@@ -1,5 +1,7 @@
 package ch.epfl.sdp.mobile.infrastructure.persistence.store
 
+import kotlin.jvm.Throws
+
 /**
  * An interface representing a place where collections are stored. This is the top-level of the
  * database hierarchy.
@@ -15,9 +17,11 @@ interface Store {
    *
    * This function may throw an [Exception] if a transaction can't be executed.
    *
+   * @throws Exception if a transaction fails.
    * @param R the type of the return value.
    * @param block the body of the [Transaction] to be executed.
    * @return the return value of the transaction.
    */
+  @Throws(Exception::class)
   suspend fun <R> transaction(block: Transaction<DocumentReference>.() -> R): R
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Store.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Store.kt
@@ -8,4 +8,16 @@ interface Store {
 
   /** Accesses a collection with the given [String] identifier. */
   fun collection(path: String): CollectionReference
+
+  /**
+   * Runs the give [Transaction] on the [Store], executing all the operations atomically. A
+   * [Transaction] must perform all its reads before performing all of its writes.
+   *
+   * This function may throw an [Exception] if a transaction can't be executed.
+   *
+   * @param R the type of the return value.
+   * @param block the body of the [Transaction] to be executed.
+   * @return the return value of the transaction.
+   */
+  suspend fun <R> transaction(block: Transaction<DocumentReference>.() -> R): R
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Transaction.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Transaction.kt
@@ -64,8 +64,8 @@ interface Transaction<out D> {
  * @param reference the [DocumentReference] to set.
  * @param value the value of the document which should be set. Existing fields will be discarded.
  */
-inline fun <reified T : Any, D> Transaction<D>.set(
-    reference: D,
+inline fun <reified T : Any> Transaction<DocumentReference>.set(
+    reference: DocumentReference,
     value: T,
 ) = set(reference, value, T::class)
 
@@ -76,6 +76,6 @@ inline fun <reified T : Any, D> Transaction<D>.set(
  * @param T the type of the document.
  * @return the [T] which was fetched.
  */
-inline fun <reified T : Any, D> Transaction<D>.get(
-    reference: D,
+inline fun <reified T : Any> Transaction<DocumentReference>.get(
+    reference: DocumentReference,
 ): T? = getSnapshot(reference).toObject(T::class)

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Transaction.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/Transaction.kt
@@ -1,0 +1,81 @@
+package ch.epfl.sdp.mobile.infrastructure.persistence.store
+
+import kotlin.reflect.KClass
+
+/**
+ * A [Transaction] offers a way for clients to perform multiple [get] of documents, followed by some
+ * [set] and [update]. At most 500 documents may be modified per [Transaction].
+ *
+ * Transactions should not have side-effects, as they might be retried if they failed in the first
+ * place.
+ *
+ * @param D the type of the document references used by [Transaction].
+ */
+interface Transaction<out D> {
+
+  /**
+   * Sets the given [DocumentReference] using the provided [scope].
+   *
+   * @param reference the [DocumentReference] to set.
+   * @param scope the [DocumentEditScope] in which editing operations are taking place. Existing
+   * fields will be discarded, and the document will be created if it wasn't present previously.
+   */
+  fun set(reference: @UnsafeVariance D, scope: DocumentEditScope.() -> Unit)
+
+  /**
+   * Sets the given [DocumentReference] with the provided [value].
+   *
+   * @param T the type of the document.
+   * @param reference the [DocumentReference] to set.
+   * @param value the value of the document which should be set. Existing fields will be discarded.
+   * @param valueClass the [KClass] of the item that is set.
+   */
+  fun <T : Any> set(reference: @UnsafeVariance D, value: T, valueClass: KClass<T>)
+
+  /**
+   * Updates the given [DocumentReference] using the provided [scope].
+   *
+   * @param reference the [DocumentReference] to update.
+   * @param scope the [DocumentEditScope] in which editing operations are taking place. Existing
+   * fields will be preserved, and the document will be created if it wasn't present previously.
+   */
+  fun update(reference: @UnsafeVariance D, scope: DocumentEditScope.() -> Unit)
+
+  /**
+   * Deletes the given [DocumentReference].
+   *
+   * @param reference the [DocumentReference] to remove.
+   */
+  fun delete(reference: @UnsafeVariance D)
+
+  /**
+   * Retrieves the [DocumentSnapshot] for the provided [DocumentReference].
+   *
+   * @param reference the [DocumentReference] to fetch.
+   * @return the [DocumentSnapshot] which was fetched.
+   */
+  fun getSnapshot(reference: @UnsafeVariance D): DocumentSnapshot
+}
+
+/**
+ * Sets the given [DocumentReference] with the provided [value].
+ *
+ * @param T the type of the document.
+ * @param reference the [DocumentReference] to set.
+ * @param value the value of the document which should be set. Existing fields will be discarded.
+ */
+inline fun <reified T : Any, D> Transaction<D>.set(
+    reference: D,
+    value: T,
+) = set(reference, value, T::class)
+
+/**
+ * Retrieves the [DocumentSnapshot] for the provided [DocumentReference].
+ *
+ * @param reference the [DocumentReference] to fetch.
+ * @param T the type of the document.
+ * @return the [T] which was fetched.
+ */
+inline fun <reified T : Any, D> Transaction<D>.get(
+    reference: D,
+): T? = getSnapshot(reference).toObject(T::class)

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreStore.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreStore.kt
@@ -1,8 +1,11 @@
 package ch.epfl.sdp.mobile.infrastructure.persistence.store.firestore
 
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.CollectionReference
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentReference
 import ch.epfl.sdp.mobile.infrastructure.persistence.store.Store
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.Transaction
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
 
 /**
  * An implementation of [Store] which uses Firestore under-the-hood.
@@ -15,4 +18,8 @@ class FirestoreStore(
 
   override fun collection(path: String): CollectionReference =
       FirestoreCollectionReference(firestore.collection(path))
+
+  override suspend fun <R> transaction(
+      block: Transaction<DocumentReference>.() -> R,
+  ): R = firestore.runTransaction { block(FirestoreTransaction(it)) }.await()
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreTransaction.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/store/firestore/FirestoreTransaction.kt
@@ -1,0 +1,48 @@
+package ch.epfl.sdp.mobile.infrastructure.persistence.store.firestore
+
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentEditScope
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.DocumentSnapshot
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.RecordingDocumentEditScope
+import ch.epfl.sdp.mobile.infrastructure.persistence.store.Transaction
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.Transaction as ActualTransaction
+import kotlin.reflect.KClass
+
+class FirestoreTransaction(
+    private val actual: ActualTransaction,
+) : Transaction<FirestoreDocumentReference> {
+
+  override fun set(
+      reference: FirestoreDocumentReference,
+      scope: DocumentEditScope.() -> Unit,
+  ) {
+    val document = RecordingDocumentEditScope().also(scope).mutations.toFirestoreDocument()
+    actual.set(reference.actual, document)
+  }
+
+  override fun <T : Any> set(
+      reference: FirestoreDocumentReference,
+      value: T,
+      valueClass: KClass<T>,
+  ) {
+    actual.set(reference.actual, value)
+  }
+
+  override fun update(
+      reference: FirestoreDocumentReference,
+      scope: DocumentEditScope.() -> Unit,
+  ) {
+    val document = RecordingDocumentEditScope().also(scope).mutations.toFirestoreDocument()
+    actual.set(reference.actual, document, SetOptions.merge())
+  }
+
+  override fun delete(
+      reference: FirestoreDocumentReference,
+  ) {
+    actual.delete(reference.actual)
+  }
+
+  override fun getSnapshot(
+      reference: FirestoreDocumentReference,
+  ): DocumentSnapshot = FirestoreDocumentSnapshot(actual.get(reference.actual))
+}


### PR DESCRIPTION
This PR adds full support for transactions to `FirestoreStore`, and minimal support for transactions to `FakeStore` (transactions semantics are not respected, but instead document reads and writes are always performed and succeed in order).