### PR TITLE
Add the next step banner

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/tournaments/NextStepBannerTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/tournaments/NextStepBannerTest.kt
@@ -1,0 +1,44 @@
+package ch.epfl.sdp.mobile.test.ui.tournaments
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import ch.epfl.sdp.mobile.ui.tournaments.GreenNextStepBanner
+import ch.epfl.sdp.mobile.ui.tournaments.OrangeNextStepBanner
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.channels.Channel
+import org.junit.Rule
+import org.junit.Test
+
+class NextStepBannerTest {
+
+  @get:Rule val rule = createComposeRule()
+
+  @Test
+  fun given_greenBanner_when_clicking_then_callsCallback() {
+    val channel = Channel<Unit>(1)
+    rule.setContent {
+      GreenNextStepBanner(
+          title = "hello",
+          message = "there",
+          onClick = { channel.trySend(Unit) },
+      )
+    }
+    rule.onNodeWithText("hello").performClick()
+    assertThat(channel.tryReceive().getOrNull()).isEqualTo(Unit)
+  }
+
+  @Test
+  fun given_orangeBanner_when_clicking_then_callsCallback() {
+    val channel = Channel<Unit>(1)
+    rule.setContent {
+      OrangeNextStepBanner(
+          title = "hello",
+          message = "there",
+          onClick = { channel.trySend(Unit) },
+      )
+    }
+    rule.onNodeWithText("hello").performClick()
+    assertThat(channel.tryReceive().getOrNull()).isEqualTo(Unit)
+  }
+}

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/tournaments/TournamentsDetailsTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/tournaments/TournamentsDetailsTest.kt
@@ -24,14 +24,24 @@ class TournamentsDetailsTest {
     override fun PoolMember.scoreAgainst(other: PoolMember): PoolScore? = null
   }
 
+  class TABTournamentsFinalRound(
+      match: TournamentMatch,
+      override val banner: TournamentsFinalsRound.Banner?,
+  ) : TournamentsFinalsRound<TournamentMatch> {
+    override val name = "TAB"
+    override val matches = listOf(match)
+    override fun onBannerClick() = Unit
+  }
+
   class OneMatchTournamentDetails(
       val match: TournamentMatch,
+      banner: TournamentsFinalsRound.Banner? = null,
   ) : TournamentDetailsState<PoolMember, TournamentMatch> {
     var clicked = false
     override val badge: BadgeType? = null
     override val title = ""
     override val pools = listOf(EmptyPoolInfo)
-    override val finals = listOf(TournamentsFinalsRound("TAB", listOf(match)))
+    override val finals = listOf(TABTournamentsFinalRound(match, banner))
     override fun onBadgeClick() = Unit
     override fun onWatchMatchClick(match: TournamentMatch) {
       clicked = true
@@ -132,5 +142,35 @@ class TournamentsDetailsTest {
     rule.onNodeWithText("TAB").performClick()
     rule.onNodeWithText(strings.tournamentsDetailsMatchWon).assertIsDisplayed()
     rule.onNodeWithText(strings.tournamentsDetailsMatchLost).assertIsDisplayed()
+  }
+
+  @Test
+  fun given_greenBanner_when_displayingFinals_then_displaysCorrectText() {
+    val match =
+        object : TournamentMatch {
+          override val firstPlayerName = "Alexandre"
+          override val secondPlayerName = "Matthieu"
+          override val result = TournamentMatch.Result.SecondWon
+        }
+    val details = OneMatchTournamentDetails(match, TournamentsFinalsRound.Banner.NextBestOf(1, 2))
+    val strings = rule.setContentWithLocalizedStrings { TournamentDetails(details) }
+    rule.onNodeWithText("TAB").performClick()
+    rule.onNodeWithText(strings.tournamentsDetailsNextBestOfTitle(1, 2)).assertIsDisplayed()
+    rule.onNodeWithText(strings.tournamentsDetailsNextBestOfSubtitle).assertIsDisplayed()
+  }
+
+  @Test
+  fun given_orangeBanner_when_displayingFinals_then_displaysCorrectText() {
+    val match =
+        object : TournamentMatch {
+          override val firstPlayerName = "Alexandre"
+          override val secondPlayerName = "Matthieu"
+          override val result = TournamentMatch.Result.SecondWon
+        }
+    val details = OneMatchTournamentDetails(match, TournamentsFinalsRound.Banner.NextRound)
+    val strings = rule.setContentWithLocalizedStrings { TournamentDetails(details) }
+    rule.onNodeWithText("TAB").performClick()
+    rule.onNodeWithText(strings.tournamentsDetailsNextRoundTitle).assertIsDisplayed()
+    rule.onNodeWithText(strings.tournamentsDetailsNextRoundSubtitle).assertIsDisplayed()
   }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/Graphics.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/Graphics.kt
@@ -2,6 +2,7 @@ package ch.epfl.sdp.mobile.ui
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.SkipNext
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
@@ -66,6 +67,9 @@ val PawniesIcons.OnlinePlay
 
 val PawniesIcons.TournamentDetailsClose
   @Composable get() = Icons.Rounded.Close
+
+val PawniesIcons.TournamentsNextStep
+  get() = Icons.Outlined.SkipNext
 
 /** Chess pieces */
 object ChessIcons

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/i18n/English.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/i18n/English.kt
@@ -116,6 +116,13 @@ object English : LocalizedStrings {
   override val tournamentsDetailsMatchDrawn = "Draw".uppercase()
   override val tournamentsDetailsHeaderOngoing = "Ongoing".uppercase()
   override val tournamentsDetailsHeaderDone = "Done".uppercase()
+  override val tournamentsDetailsNextBestOfTitle = { round: Int, total: Int ->
+    "Create match $round / $total"
+  }
+  override val tournamentsDetailsNextBestOfSubtitle =
+      "Add a new match to all the players in this round."
+  override val tournamentsDetailsNextRoundTitle = "Next round"
+  override val tournamentsDetailsNextRoundSubtitle = "Move all the winners to the next round"
 
   override val tournamentsCreateTitle = "Create tournament"
   override val tournamentsCreateNameHint = "Name"

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/i18n/LocalizedStrings.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/i18n/LocalizedStrings.kt
@@ -118,6 +118,10 @@ interface LocalizedStrings {
   val tournamentsDetailsMatchDrawn: String
   val tournamentsDetailsHeaderOngoing: String
   val tournamentsDetailsHeaderDone: String
+  val tournamentsDetailsNextBestOfTitle: (Int, Int) -> String
+  val tournamentsDetailsNextBestOfSubtitle: String
+  val tournamentsDetailsNextRoundTitle: String
+  val tournamentsDetailsNextRoundSubtitle: String
 
   val tournamentsCreateTitle: String
   val tournamentsCreateNameHint: String

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/NextStepBanner.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/NextStepBanner.kt
@@ -1,0 +1,114 @@
+package ch.epfl.sdp.mobile.ui.tournaments
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import ch.epfl.sdp.mobile.ui.PawniesColors
+import ch.epfl.sdp.mobile.ui.PawniesIcons
+import ch.epfl.sdp.mobile.ui.TournamentsNextStep
+
+/**
+ * A green variation of [NextStepBanner].
+ *
+ * @see NextStepBanner
+ */
+@Composable
+fun GreenNextStepBanner(
+    title: String,
+    message: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+  NextStepBanner(
+      title = title,
+      message = message,
+      onClick = onClick,
+      titleColor = PawniesColors.Green800,
+      messageColor = PawniesColors.Green500,
+      backgroundColor = PawniesColors.Green100.copy(alpha = 0.4f),
+      borderColor = PawniesColors.Green200,
+      modifier = modifier,
+  )
+}
+
+/**
+ * An orange variation of [NextStepBanner].
+ *
+ * @see NextStepBanner
+ */
+@Composable
+fun OrangeNextStepBanner(
+    title: String,
+    message: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+  NextStepBanner(
+      title = title,
+      message = message,
+      onClick = onClick,
+      titleColor = PawniesColors.Orange500,
+      messageColor = PawniesColors.Orange500,
+      backgroundColor = PawniesColors.Orange200.copy(alpha = 0.2f),
+      borderColor = PawniesColors.Orange500,
+      modifier = modifier,
+  )
+}
+
+/**
+ * A banner which indicates a next step of a round.
+ *
+ * @param title the title of the banner.
+ * @param message the message of the banner.
+ * @param onClick the listener called when the banner is clicked.
+ * @param titleColor the color of the title.
+ * @param messageColor the color of the message.
+ * @param backgroundColor the color of the background.
+ * @param borderColor the color of the border.
+ * @param modifier the [Modifier] for this composable.
+ */
+@Composable
+private fun NextStepBanner(
+    title: String,
+    message: String,
+    onClick: () -> Unit,
+    titleColor: Color,
+    messageColor: Color,
+    backgroundColor: Color,
+    borderColor: Color,
+    modifier: Modifier = Modifier,
+) {
+  Row(
+      modifier =
+          modifier
+              .fillMaxWidth()
+              .border(2.dp, borderColor, RoundedCornerShape(16.dp))
+              .clip(RoundedCornerShape(16.dp))
+              .clickable { onClick() }
+              .background(backgroundColor)
+              .padding(16.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(Modifier.weight(1f)) {
+      Text(text = title, style = MaterialTheme.typography.subtitle1, color = titleColor)
+      Text(text = message, style = MaterialTheme.typography.body1, color = messageColor)
+    }
+    CompositionLocalProvider(LocalContentColor provides titleColor) {
+      Icon(PawniesIcons.TournamentsNextStep, null)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the next step banner, which lets the admin users move forward with the elimination rounds.

## Deliverables

![telegram-cloud-photo-size-4-6039855940083235009-y](https://user-images.githubusercontent.com/6318990/167515098-e5f8ef5b-03ae-487b-9004-c7e62a1bd769.jpg)
