### PR TITLE
Refactor the `MatchChessBoardState`

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulGameScreenTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulGameScreenTest.kt
@@ -19,8 +19,8 @@ import ch.epfl.sdp.mobile.application.social.SocialFacade
 import ch.epfl.sdp.mobile.application.speech.SpeechFacade
 import ch.epfl.sdp.mobile.infrastructure.speech.SpeechRecognizerFactory
 import ch.epfl.sdp.mobile.state.*
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toEngineRank
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toRank
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toEngineRank
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toRank
 import ch.epfl.sdp.mobile.test.application.chess.engine.Games.FoolsMate
 import ch.epfl.sdp.mobile.test.application.chess.engine.Games.Stalemate
 import ch.epfl.sdp.mobile.test.application.chess.engine.Games.UntilPromotion

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/game/MatchChessBoardStateTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/game/MatchChessBoardStateTest.kt
@@ -3,12 +3,12 @@ package ch.epfl.sdp.mobile.test.state.game
 import ch.epfl.sdp.mobile.application.chess.engine.Color as EngineColor
 import ch.epfl.sdp.mobile.application.chess.engine.Position as EnginePosition
 import ch.epfl.sdp.mobile.application.chess.engine.Rank
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toColor
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toEngineColor
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toEnginePosition
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toEngineRank
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toPosition
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toRank
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toColor
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toEngineColor
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toEnginePosition
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toEngineRank
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toPosition
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toRank
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/AbstractMovableChessBoardState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/AbstractMovableChessBoardState.kt
@@ -1,0 +1,61 @@
+package ch.epfl.sdp.mobile.state.game
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import ch.epfl.sdp.mobile.application.chess.engine.Position
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toPosition
+import ch.epfl.sdp.mobile.ui.game.ChessBoardState
+import ch.epfl.sdp.mobile.ui.game.MovableChessBoardState
+
+/**
+ * An abstract implementation of [MovableChessBoardState] which delegates the updates of the game to
+ * its [GameChessBoardState].
+ *
+ * @param delegate the [GameChessBoardState] delegate.
+ */
+abstract class AbstractMovableChessBoardState(
+    delegate: GameChessBoardState,
+) : MovableChessBoardState<GameChessBoardState.Piece>, GameChessBoardState by delegate {
+
+  /**
+   * Attempts to perform a move from the given [ChessBoardState.Position] to the given
+   * [ChessBoardState.Position]. If the move can't be performed, this will result in a no-op.
+   *
+   * @param from the start [ChessBoardState.Position].
+   * @param to the end [ChessBoardState.Position].
+   */
+  abstract fun tryPerformMove(from: ChessBoardState.Position, to: ChessBoardState.Position)
+
+  final override var selectedPosition by mutableStateOf<ChessBoardState.Position?>(null)
+    private set
+
+  override val availableMoves: Set<ChessBoardState.Position>
+    // Display all the possible moves for all the pieces on the board.
+    get() {
+      val position = selectedPosition ?: return emptySet()
+      return game.actions(Position(position.x, position.y))
+          .mapNotNull { it.from + it.delta }
+          .map { it.toPosition() }
+          .toSet()
+    }
+
+  override fun onDropPiece(
+      piece: GameChessBoardState.Piece,
+      endPosition: ChessBoardState.Position,
+  ) {
+    val startPosition = pieces.entries.firstOrNull { it.value == piece }?.key ?: return
+    selectedPosition = null
+    tryPerformMove(startPosition, endPosition)
+  }
+
+  override fun onPositionClick(position: ChessBoardState.Position) {
+    val from = selectedPosition
+    if (from == null) {
+      selectedPosition = position
+    } else {
+      selectedPosition = null
+      tryPerformMove(from, position)
+    }
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/GameChessBoardState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/GameChessBoardState.kt
@@ -1,0 +1,124 @@
+package ch.epfl.sdp.mobile.state.game
+
+import ch.epfl.sdp.mobile.application.chess.Match
+import ch.epfl.sdp.mobile.application.chess.engine.*
+import ch.epfl.sdp.mobile.application.chess.engine.Piece as EnginePiece
+import ch.epfl.sdp.mobile.application.chess.engine.Position as EnginePosition
+import ch.epfl.sdp.mobile.application.chess.engine.rules.Action
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Piece
+import ch.epfl.sdp.mobile.ui.game.ChessBoardState
+
+interface GameChessBoardState : ChessBoardState<Piece> {
+
+  /** The current [Game], which is updated when the [Match] progresses. */
+  var game: Game
+
+  override val pieces: Map<ChessBoardState.Position, Piece>
+    get() = game.board.associate { (pos, piece) -> pos.toPosition() to Piece(piece) }
+
+  override val checkPosition: ChessBoardState.Position?
+    get() {
+      val nextStep = game.nextStep
+      if (nextStep !is NextStep.MovePiece || !nextStep.inCheck) return null
+      return game.board
+          .firstNotNullOf { (position, piece) ->
+            position.takeIf { piece.color == nextStep.turn && piece.rank == Rank.King }
+          }
+          .toPosition()
+    }
+
+  /** Returns the available actions [from] a position [to] another. */
+  fun availableActions(
+      from: ChessBoardState.Position,
+      to: ChessBoardState.Position,
+  ): List<Action> {
+    return game.actions(EnginePosition(from.x, from.y))
+        .filter { it.from + it.delta == EnginePosition(to.x, to.y) }
+        .toList()
+  }
+
+  /**
+   * An implementation of [Piece] which uses an [EnginePiece] internally.
+   *
+   * @param piece backing [EnginePiece].
+   */
+  data class Piece(private val piece: EnginePiece<Color>) : ChessBoardState.Piece {
+    override val rank = piece.rank.toRank()
+    override val color = piece.color.toColor()
+  }
+
+  companion object {
+
+    /**
+     * Maps a [ChessBoardState.Color] to an [EngineColor].
+     *
+     * @receiver the [ChessBoardState.Color] to map.
+     * @return the resulting [EngineColor].
+     */
+    fun ChessBoardState.Color.toEngineColor(): Color =
+        when (this) {
+          ChessBoardState.Color.Black -> Color.Black
+          ChessBoardState.Color.White -> Color.White
+        }
+
+    /**
+     * Maps a [ChessBoardState.Position] to an [EnginePosition].
+     *
+     * @receiver the [ChessBoardState.Position] to map.
+     * @return the resulting [EnginePosition].
+     */
+    fun ChessBoardState.Position.toEnginePosition(): EnginePosition = EnginePosition(x, y)
+
+    /**
+     * Maps a [ChessBoardState.Rank] to an [EngineRank].
+     *
+     * @receiver the [ChessBoardState.Rank] to map.
+     * @return the resulting [EngineRank].
+     */
+    fun ChessBoardState.Rank.toEngineRank(): Rank =
+        when (this) {
+          ChessBoardState.Rank.King -> Rank.King
+          ChessBoardState.Rank.Queen -> Rank.Queen
+          ChessBoardState.Rank.Rook -> Rank.Rook
+          ChessBoardState.Rank.Bishop -> Rank.Bishop
+          ChessBoardState.Rank.Knight -> Rank.Knight
+          ChessBoardState.Rank.Pawn -> Rank.Pawn
+        }
+
+    /**
+     * Maps an [EngineColor] to a [ChessBoardState.Color].
+     *
+     * @receiver the [EngineColor] to map.
+     * @return the resulting [ChessBoardState.Color].
+     */
+    fun Color.toColor(): ChessBoardState.Color =
+        when (this) {
+          Color.Black -> ChessBoardState.Color.Black
+          Color.White -> ChessBoardState.Color.White
+        }
+
+    /**
+     * Maps an [EnginePosition] to a [ChessBoardState.Position].
+     *
+     * @receiver the [EnginePosition] to map.
+     * @return the resulting [ChessBoardState.Position].
+     */
+    fun EnginePosition.toPosition(): ChessBoardState.Position = ChessBoardState.Position(x, y)
+
+    /**
+     * Maps an [EngineRank] to a [ChessBoardState.Rank].
+     *
+     * @receiver the [EngineRank] to map.
+     * @return the resulting [ChessBoardState.Rank].
+     */
+    fun Rank.toRank(): ChessBoardState.Rank =
+        when (this) {
+          Rank.King -> ChessBoardState.Rank.King
+          Rank.Queen -> ChessBoardState.Rank.Queen
+          Rank.Rook -> ChessBoardState.Rank.Rook
+          Rank.Bishop -> ChessBoardState.Rank.Bishop
+          Rank.Knight -> ChessBoardState.Rank.Knight
+          Rank.Pawn -> ChessBoardState.Rank.Pawn
+        }
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/GamePromotionState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/GamePromotionState.kt
@@ -1,0 +1,65 @@
+package ch.epfl.sdp.mobile.state.game
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import ch.epfl.sdp.mobile.application.chess.engine.NextStep
+import ch.epfl.sdp.mobile.application.chess.engine.Position
+import ch.epfl.sdp.mobile.application.chess.engine.rules.Action
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toEngineRank
+import ch.epfl.sdp.mobile.ui.game.ChessBoardState
+import ch.epfl.sdp.mobile.ui.game.PromotionState
+
+class GamePromotionState(
+    private val delegate: GameChessBoardState,
+) : PromotionState, GameChessBoardState by delegate {
+
+  override var choices: List<ChessBoardState.Rank> by mutableStateOf(emptyList())
+
+  override val confirmEnabled: Boolean
+    get() = selection != null
+
+  override var selection: ChessBoardState.Rank? by mutableStateOf(null)
+    private set
+
+  /** The start position from the promotion. */
+  private var promotionFrom by mutableStateOf(ChessBoardState.Position(0, 0))
+
+  /** The end position from the promotion. */
+  private var promotionTo by mutableStateOf(ChessBoardState.Position(0, 0))
+
+  override fun onSelect(rank: ChessBoardState.Rank) {
+    selection = if (rank == selection) null else rank
+  }
+
+  override fun onConfirm() {
+    val rank = selection ?: return
+    selection = null
+    val action =
+        Action.Promote(
+            from = Position(promotionFrom.x, promotionFrom.y),
+            to = Position(promotionTo.x, promotionTo.y),
+            rank = rank.toEngineRank(),
+        )
+    val step = game.nextStep as? NextStep.MovePiece ?: return
+    game = step.move(action)
+    choices = emptyList()
+  }
+
+  /**
+   * Updates the promotion choices.
+   *
+   * @param from the original promotion position.
+   * @param to the final promotion position.
+   * @param choices the possible ranks for promotion.
+   */
+  fun updatePromotion(
+      from: ChessBoardState.Position,
+      to: ChessBoardState.Position,
+      choices: List<ChessBoardState.Rank>,
+  ) {
+    this.promotionFrom = from
+    this.promotionTo = to
+    this.choices = choices
+  }
+}

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/MatchChessBoardState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/MatchChessBoardState.kt
@@ -4,13 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import ch.epfl.sdp.mobile.application.chess.Match
-import ch.epfl.sdp.mobile.application.chess.engine.Color as EngineColor
 import ch.epfl.sdp.mobile.application.chess.engine.Game
-import ch.epfl.sdp.mobile.application.chess.engine.NextStep
-import ch.epfl.sdp.mobile.application.chess.engine.Piece as EnginePiece
-import ch.epfl.sdp.mobile.application.chess.engine.Position as EnginePosition
-import ch.epfl.sdp.mobile.application.chess.engine.Rank as EngineRank
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Piece
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -23,114 +17,20 @@ import kotlinx.coroutines.launch
  * @param scope the [CoroutineScope] in which the match is observed.
  */
 class MatchChessBoardState(
-    match: Match,
-    scope: CoroutineScope,
-) : ChessBoardState<Piece> {
+    private val match: Match,
+    private val scope: CoroutineScope,
+) : GameChessBoardState {
 
-  /** The current [Game], which is updated when the [Match] progresses. */
-  var game by mutableStateOf(Game.create())
-    private set
+  private var backing by mutableStateOf(Game.create())
 
-  init {
-    scope.launch { match.game.collect { game = it } }
-  }
-
-  override val pieces: Map<ChessBoardState.Position, Piece>
-    get() = game.board.associate { (pos, piece) -> pos.toPosition() to Piece(piece) }
-
-  override val checkPosition: ChessBoardState.Position?
-    get() {
-      val nextStep = game.nextStep
-      if (nextStep !is NextStep.MovePiece || !nextStep.inCheck) return null
-      return game.board
-          .firstNotNullOf { (position, piece) ->
-            position.takeIf { piece.color == nextStep.turn && piece.rank == EngineRank.King }
-          }
-          .toPosition()
+  override var game: Game
+    get() = backing
+    set(value) {
+      backing = value // Local updates
+      scope.launch { match.update(value) }
     }
 
-  /**
-   * An implementation of [Piece] which uses an [EnginePiece] internally.
-   *
-   * @param piece backing [EnginePiece].
-   */
-  data class Piece(private val piece: EnginePiece<EngineColor>) : ChessBoardState.Piece {
-    override val rank = piece.rank.toRank()
-    override val color = piece.color.toColor()
-  }
-
-  companion object {
-
-    /**
-     * Maps a [ChessBoardState.Color] to an [EngineColor].
-     *
-     * @receiver the [ChessBoardState.Color] to map.
-     * @return the resulting [EngineColor].
-     */
-    fun ChessBoardState.Color.toEngineColor(): EngineColor =
-        when (this) {
-          ChessBoardState.Color.Black -> EngineColor.Black
-          ChessBoardState.Color.White -> EngineColor.White
-        }
-
-    /**
-     * Maps a [ChessBoardState.Position] to an [EnginePosition].
-     *
-     * @receiver the [ChessBoardState.Position] to map.
-     * @return the resulting [EnginePosition].
-     */
-    fun ChessBoardState.Position.toEnginePosition(): EnginePosition = EnginePosition(x, y)
-
-    /**
-     * Maps a [ChessBoardState.Rank] to an [EngineRank].
-     *
-     * @receiver the [ChessBoardState.Rank] to map.
-     * @return the resulting [EngineRank].
-     */
-    fun ChessBoardState.Rank.toEngineRank(): EngineRank =
-        when (this) {
-          ChessBoardState.Rank.King -> EngineRank.King
-          ChessBoardState.Rank.Queen -> EngineRank.Queen
-          ChessBoardState.Rank.Rook -> EngineRank.Rook
-          ChessBoardState.Rank.Bishop -> EngineRank.Bishop
-          ChessBoardState.Rank.Knight -> EngineRank.Knight
-          ChessBoardState.Rank.Pawn -> EngineRank.Pawn
-        }
-
-    /**
-     * Maps an [EngineColor] to a [ChessBoardState.Color].
-     *
-     * @receiver the [EngineColor] to map.
-     * @return the resulting [ChessBoardState.Color].
-     */
-    fun EngineColor.toColor(): ChessBoardState.Color =
-        when (this) {
-          EngineColor.Black -> ChessBoardState.Color.Black
-          EngineColor.White -> ChessBoardState.Color.White
-        }
-
-    /**
-     * Maps an [EnginePosition] to a [ChessBoardState.Position].
-     *
-     * @receiver the [EnginePosition] to map.
-     * @return the resulting [ChessBoardState.Position].
-     */
-    fun EnginePosition.toPosition(): ChessBoardState.Position = ChessBoardState.Position(x, y)
-
-    /**
-     * Maps an [EngineRank] to a [ChessBoardState.Rank].
-     *
-     * @receiver the [EngineRank] to map.
-     * @return the resulting [ChessBoardState.Rank].
-     */
-    fun EngineRank.toRank(): ChessBoardState.Rank =
-        when (this) {
-          EngineRank.King -> ChessBoardState.Rank.King
-          EngineRank.Queen -> ChessBoardState.Rank.Queen
-          EngineRank.Rook -> ChessBoardState.Rank.Rook
-          EngineRank.Bishop -> ChessBoardState.Rank.Bishop
-          EngineRank.Knight -> ChessBoardState.Rank.Knight
-          EngineRank.Pawn -> ChessBoardState.Rank.Pawn
-        }
+  init {
+    scope.launch { match.game.collect { backing = it } }
   }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/MatchGameScreenState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/MatchGameScreenState.kt
@@ -8,14 +8,11 @@ import ch.epfl.sdp.mobile.application.authentication.AuthenticatedUser
 import ch.epfl.sdp.mobile.application.chess.Match
 import ch.epfl.sdp.mobile.application.chess.engine.Color
 import ch.epfl.sdp.mobile.application.chess.engine.NextStep
-import ch.epfl.sdp.mobile.application.chess.engine.Position
-import ch.epfl.sdp.mobile.application.chess.engine.rules.Action
+import ch.epfl.sdp.mobile.application.chess.engine.rules.Action.Promote
 import ch.epfl.sdp.mobile.application.chess.notation.AlgebraicNotation.toAlgebraicNotation
 import ch.epfl.sdp.mobile.state.StatefulGameScreenActions
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toEngineRank
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toPosition
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Companion.toRank
-import ch.epfl.sdp.mobile.state.game.MatchChessBoardState.Piece
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Companion.toRank
+import ch.epfl.sdp.mobile.state.game.GameChessBoardState.Piece
 import ch.epfl.sdp.mobile.ui.game.ChessBoardState
 import ch.epfl.sdp.mobile.ui.game.GameScreenState
 import ch.epfl.sdp.mobile.ui.game.GameScreenState.Message
@@ -24,6 +21,34 @@ import ch.epfl.sdp.mobile.ui.game.PromotionState
 import ch.epfl.sdp.mobile.ui.game.SpeechRecognizerState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+
+/**
+ * Creates a new [MatchGameScreenState].
+ *
+ * @param actions the actions to perform when navigating.
+ * @param user the currently authenticated user.
+ * @param match the match to display.
+ * @param scope a [CoroutineScope] keeping track of the state lifecycle.
+ * @param speechRecognizerState the [SpeechRecognizerState] that speech recognition uses.
+ */
+fun MatchGameScreenState(
+    actions: StatefulGameScreenActions,
+    user: AuthenticatedUser,
+    match: Match,
+    scope: CoroutineScope,
+    speechRecognizerState: SpeechRecognizerState,
+): MatchGameScreenState {
+  val chessBoardDelegate = MatchChessBoardState(match, scope)
+  return MatchGameScreenState(
+      actions,
+      user,
+      match,
+      scope,
+      chessBoardDelegate,
+      GamePromotionState(chessBoardDelegate),
+      speechRecognizerState,
+  )
+}
 
 /**
  * An implementation of [GameScreenState] and [PromotionState] that starts with default chess
@@ -37,35 +62,19 @@ import kotlinx.coroutines.launch
  * @param speechRecognizerDelegate the [SpeechRecognizerState] to delegate to
  */
 class MatchGameScreenState
-private constructor(
+constructor(
     private val actions: StatefulGameScreenActions,
     private val user: AuthenticatedUser,
     private val match: Match,
     private val scope: CoroutineScope,
-    private val chessBoardDelegate: MatchChessBoardState,
+    private val chessBoardDelegate: GameChessBoardState,
+    private val promotionState: GamePromotionState,
     private val speechRecognizerDelegate: SpeechRecognizerState,
 ) :
+    AbstractMovableChessBoardState(chessBoardDelegate),
     GameScreenState<Piece>,
-    PromotionState,
-    ChessBoardState<Piece> by chessBoardDelegate,
+    PromotionState by promotionState,
     SpeechRecognizerState by speechRecognizerDelegate {
-
-  /**
-   * Creates a new [MatchGameScreenState].
-   *
-   * @param actions the actions to perform when navigating.
-   * @param user the currently authenticated user.
-   * @param match the match to display.
-   * @param scope a [CoroutineScope] keeping track of the state lifecycle.
-   * @param speechRecognizerState the [SpeechRecognizerState] that speech recognition uses.
-   */
-  constructor(
-      actions: StatefulGameScreenActions,
-      user: AuthenticatedUser,
-      match: Match,
-      scope: CoroutineScope,
-      speechRecognizerState: SpeechRecognizerState,
-  ) : this(actions, user, match, scope, MatchChessBoardState(match, scope), speechRecognizerState)
 
   override fun onArClick() = actions.onShowAr(match)
 
@@ -100,114 +109,27 @@ private constructor(
     scope.launch { match.black.collect { blackProfile = it } }
   }
 
-  /** The currently selected [Position] of the board. */
-  override var selectedPosition by mutableStateOf<ChessBoardState.Position?>(null)
-    private set
+  override val moves: List<Move>
+    get() = game.toAlgebraicNotation().map(::Move)
 
-  override val availableMoves: Set<ChessBoardState.Position>
-    // Display all the possible moves for all the pieces on the board.
-    get() {
-      val position = selectedPosition ?: return emptySet()
-      return chessBoardDelegate
-          .game
-          .actions(Position(position.x, position.y))
-          .mapNotNull { it.from + it.delta }
-          .map { it.toPosition() }
-          .toSet()
-    }
-
-  override fun onDropPiece(piece: Piece, endPosition: ChessBoardState.Position) {
-    val startPosition = pieces.entries.firstOrNull { it.value == piece }?.key ?: return
-    tryPerformMove(startPosition, endPosition)
-  }
-
-  override fun onPositionClick(position: ChessBoardState.Position) {
-    val from = selectedPosition
-    if (from == null) {
-      selectedPosition = position
-    } else {
-      tryPerformMove(from, position)
-    }
-  }
-
-  /**
-   * Attempts to perform a move from the given [ChessBoardState.Position] to the given
-   * [ChessBoardState.Position]. If the move can't be performed, this will result in a no-op.
-   *
-   * @param from the start [ChessBoardState.Position].
-   * @param to the end [ChessBoardState.Position].
-   */
-  private fun tryPerformMove(
-      from: ChessBoardState.Position,
-      to: ChessBoardState.Position,
-  ) {
-    // Hide the current selection.
-    selectedPosition = null
-
-    val step = chessBoardDelegate.game.nextStep as? NextStep.MovePiece ?: return
-
+  override fun tryPerformMove(from: ChessBoardState.Position, to: ChessBoardState.Position) {
+    val available = chessBoardDelegate.availableActions(from, to)
+    val step = game.nextStep as? NextStep.MovePiece ?: return
     val currentPlayingId =
         when (step.turn) {
           Color.Black -> blackProfile?.uid
           Color.White -> whiteProfile?.uid
         }
-
     if (currentPlayingId == user.uid) {
-      // TODO: Update game locally first, then verify upload was successful?
-      val actions =
-          chessBoardDelegate
-              .game
-              .actions(Position(from.x, from.y))
-              .filter { it.from + it.delta == Position(to.x, to.y) }
-              .toList()
-      if (actions.size == 1) {
-        scope.launch {
-          val newGame = step.move(actions.first())
-          match.update(newGame)
-        }
+      if (available.size == 1) {
+        game = step.move(available.first())
       } else {
-        promotionFrom = from
-        promotionTo = to
-        choices = actions.filterIsInstance<Action.Promote>().map { it.rank.toRank() }
+        promotionState.updatePromotion(
+            from = from,
+            to = to,
+            choices = available.filterIsInstance<Promote>().map { it.rank.toRank() },
+        )
       }
     }
   }
-
-  // Promotion management.
-
-  override var choices: List<ChessBoardState.Rank> by mutableStateOf(emptyList())
-    private set
-
-  override val confirmEnabled: Boolean
-    get() = selection != null
-
-  override var selection: ChessBoardState.Rank? by mutableStateOf(null)
-    private set
-
-  private var promotionFrom by mutableStateOf(ChessBoardState.Position(0, 0))
-  private var promotionTo by mutableStateOf(ChessBoardState.Position(0, 0))
-
-  override fun onConfirm() {
-    val rank = selection ?: return
-    selection = null
-    val action =
-        Action.Promote(
-            from = Position(promotionFrom.x, promotionFrom.y),
-            to = Position(promotionTo.x, promotionTo.y),
-            rank = rank.toEngineRank(),
-        )
-    val step = chessBoardDelegate.game.nextStep as? NextStep.MovePiece ?: return
-    scope.launch {
-      val newGame = step.move(action)
-      match.update(newGame)
-      choices = emptyList()
-    }
-  }
-
-  override fun onSelect(rank: ChessBoardState.Rank) {
-    selection = if (rank == selection) null else rank
-  }
-
-  override val moves: List<Move>
-    get() = chessBoardDelegate.game.toAlgebraicNotation().map(::Move)
 }


### PR DESCRIPTION
This PR refactors the `MatchChessBoardState`, to make it easier to share some logic with the puzzles screen, and better support voice recognition. Additionally, it slightly improves performance by speculatively updating the game state before pushing it to the `Store`.

(for reference : a local-only `GameChessBoardState` implementation : 
https://gist.github.com/alexandrepiveteau/bbaf67ac7c08e23eeef3a35f6fe44a84)