### PR TITLE
Add modifier on the last move

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ChessBoardTest.kt
@@ -53,6 +53,7 @@ class ChessBoardTest {
     }
 
     override fun onPositionClick(position: Position) = Unit
+    override val lastMove: Position? = null
   }
 
   @Test

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ar/ChessSceneTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ar/ChessSceneTest.kt
@@ -29,6 +29,7 @@ class ChessSceneTest {
     override val pieces: Map<ChessBoardState.Position, ChessBoardState.Piece>
       get() = mapOf(position to piece)
     override val checkPosition: ChessBoardState.Position? = null
+    override val lastMove: ChessBoardState.Position? = null
   }
 
   @Test

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/delegating/DelegatingChessBoardState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/game/delegating/DelegatingChessBoardState.kt
@@ -34,6 +34,16 @@ class DelegatingChessBoardState(private val delegate: GameDelegate) : ChessBoard
           .toPosition()
     }
 
+  override val lastMove: ChessBoardState.Position?
+    get() {
+      val previousStep = delegate.game.previous ?: return null
+      val lastAction = previousStep.second
+      return lastAction.let {
+        val lastPosition = it.from.plus(it.delta) ?: return null
+        lastPosition.toPosition()
+      }
+    }
+
   /** Returns the available actions [from] a position [to] another. */
   fun availableActions(
       from: ChessBoardState.Position,

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/Colors.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/Colors.kt
@@ -24,6 +24,7 @@ object PawniesColors {
   val Green500 = Color(0xFF379665)
   val Green800 = Color(0xFF356859)
   val Orange500 = Color(0xFFFD5523)
+  val Orange250 = Color(0xFFFD906F)
   val Orange200 = Color(0xFFF8A68D)
 }
 

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardState.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ChessBoardState.kt
@@ -54,4 +54,7 @@ interface ChessBoardState<out Piece : ChessBoardState.Piece> {
 
   /** Returns the position of the [Rank.King] currently in check, if there's any. */
   val checkPosition: Position?
+
+  /** Return the [Position] of the game's last action */
+  val lastMove: Position?
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/classic/ChessBoardModifiers.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/classic/ChessBoardModifiers.kt
@@ -2,8 +2,7 @@ package ch.epfl.sdp.mobile.ui.game.classic
 
 import androidx.compose.animation.core.*
 import androidx.compose.animation.core.AnimationConstants.DefaultDurationMillis
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.*
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
@@ -13,13 +12,11 @@ import androidx.compose.ui.draw.*
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.center
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.PathEffect.Companion.dashPathEffect
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
-import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.platform.LocalFontLoader
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.Paragraph
@@ -133,6 +130,58 @@ fun Modifier.check(
       positions = position?.let(::setOf) ?: emptySet(),
       cells = cells,
   ) { onDrawBehind { drawRect(fillColor) } }
+}
+
+/**
+ * A [Modifier] which draws the fill cell with dash border for the provided [position]. The border
+ * and the background color are the same. The alpha value of the background color is smaller.
+ *
+ * @param position the position that should be drawn.
+ * @param color the [Color] of the celle
+ * @param cells the number of cells in the grid.
+ * @param width the width of the border
+ */
+fun Modifier.lastMove(
+    position: Position?,
+    color: Color = Color.Unspecified,
+    cells: Int = ChessBoardCells,
+    width: Dp = 4.dp,
+): Modifier = composed {
+  val fillColor = color.takeOrElse { LocalContentColor.current }.copy(alpha = ContentAlpha.disabled)
+  val lineColor = color.takeOrElse { LocalContentColor.current }
+
+  val transition = rememberInfiniteTransition()
+  val progress by
+      transition.animateFloat(
+          initialValue = 0f,
+          targetValue = 1f,
+          animationSpec =
+              infiniteRepeatable(
+                  tween(
+                      durationMillis = SelectionDurationMillis,
+                      easing = LinearEasing,
+                  ),
+              ),
+      )
+  cells(
+      positions = position?.let(::setOf) ?: emptySet(),
+      cells = cells,
+  ) {
+    onDrawBehind {
+      val phase = size.width / 3
+      val style =
+          Stroke(
+              width = width.toPx(),
+              pathEffect =
+                  dashPathEffect(
+                      phase = -2 * progress * phase,
+                      intervals = floatArrayOf(phase, phase),
+                  ),
+          )
+      drawRect(color = fillColor)
+      drawRect(color = lineColor, style = style)
+    }
+  }
 }
 
 /** The duration of a cycle of the selection dashed border animation. */

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/classic/ClassicChessBoard.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/classic/ClassicChessBoard.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.consumeAllChanges
 import androidx.compose.ui.input.pointer.pointerInput
@@ -74,6 +75,10 @@ fun <Piece : ChessBoardState.Piece> ClassicChessBoard(
           .selection(
               position = state.selectedPosition,
               color = MaterialTheme.colors.secondary.copy(alpha = ContentAlpha.medium),
+          )
+          .lastMove(
+              position = state.lastMove,
+              color = PawniesColors.Orange250,
           )
           .letters(color = MaterialTheme.colors.onPrimary)
           .semantics { this.contentDescription = strings.boardContentDescription },


### PR DESCRIPTION
The player can see the last action that was performed, the cell have another colour with animated dashed lane.

Closes #357 

![image](https://user-images.githubusercontent.com/17824883/168432001-7126df69-a3df-43ed-be86-35ebb46a939c.png)
