### PR TITLE
Fix #408 and correspondings tests

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/TournamentFacadeTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/application/TournamentFacadeTest.kt
@@ -35,6 +35,7 @@ class TournamentFacadeTest {
       }
       val tournamentFacade = TournamentFacade(auth, dataStoreFactory, store, FakeTimeProvider)
       val authenticationFacade = AuthenticationFacade(auth, store)
+      authenticationFacade.signInWithEmail("a@hotmail.com", "password")
       val user = authenticationFacade.currentUser.filterIsInstance<AuthenticatedUser>().first()
 
       val tournaments = tournamentFacade.tournaments(user).first()

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/DslTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/DslTest.kt
@@ -25,6 +25,13 @@ class DslTest {
   }
 
   @Test
+  fun given_buildAuthWithOneUser_when_getsCurrentUser_then_isEmpty() = runTest {
+    val auth = buildAuth { user("alexandre.piveteau@epfl.ch", "password") }
+    val result = auth.currentUser.first()
+    assertThat(result).isNull()
+  }
+
+  @Test
   fun existingUser_canSignIn() = runTest {
     val auth = buildAuth { user("alexandre.piveteau@epfl.ch", "password") }
     val result = auth.signInWithEmail("alexandre.piveteau@epfl.ch", "password")

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/fake/FakeAuth.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/auth/fake/FakeAuth.kt
@@ -35,7 +35,7 @@ class FakeAuth : Auth, AuthBuilder {
       email: String,
       password: String,
   ): Auth.AuthenticationResult {
-    return addUser(email, password)
+    return addUser(email = email, password = password, logIn = true)
   }
 
   override suspend fun signOut() {
@@ -43,11 +43,11 @@ class FakeAuth : Auth, AuthBuilder {
   }
 
   override fun user(email: String, password: String) {
-    addUser(email, password)
+    addUser(email = email, password = password, logIn = false)
   }
 
   override fun user(email: String, password: String, uid: String) {
-    addUser(email, password, uid)
+    addUser(email = email, password = password, logIn = false, uid = uid)
   }
 
   /**
@@ -55,6 +55,7 @@ class FakeAuth : Auth, AuthBuilder {
    *
    * @param email the email address to use.
    * @param password the password of the added user.
+   * @param logIn true iff the newly added user logged in.
    * @param uid the unique identifier for this newly added user.
    *
    * @return the result of adding the new user.
@@ -62,6 +63,7 @@ class FakeAuth : Auth, AuthBuilder {
   private fun addUser(
       email: String,
       password: String,
+      logIn: Boolean,
       uid: String = UUID.randomUUID().toString(),
   ): Auth.AuthenticationResult {
 
@@ -78,7 +80,11 @@ class FakeAuth : Auth, AuthBuilder {
       if (exists) return Failure.ExistingAccount
 
       val newUser = FakeUser(uid = uid, email = email, password = password)
-      val newRec = FakeAuthRecord(currentUser = newUser, users = users + newUser)
+      val newRec =
+          FakeAuthRecord(
+              currentUser = if (logIn) newUser else rec.currentUser,
+              users = users + newUser,
+          )
 
       // Only update if the data is consistent with what we had read. Otherwise, we can safely retry
       // to perform the whole block atomically. A new UID may be generated, and we'll see newly

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulContestScreenTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulContestScreenTest.kt
@@ -55,6 +55,7 @@ class StatefulContestScreenTest {
       val speechFacade = SpeechFacade(FailingSpeechRecognizerFactory)
       val tournamentFacade = TournamentFacade(auth, dataStoreFactory, store, FakeTimeProvider)
 
+      authFacade.signInWithEmail("email@example.org", "password")
       val currentUser = authFacade.currentUser.filterIsInstance<AuthenticatedUser>().first()
       val strings =
           rule.setContentWithLocalizedStrings {
@@ -85,6 +86,7 @@ class StatefulContestScreenTest {
       val speechFacade = SpeechFacade(FailingSpeechRecognizerFactory)
       val tournamentFacade = TournamentFacade(auth, dataStoreFactory, store, FakeTimeProvider)
 
+      authFacade.signInWithEmail("email@example.org", "password")
       val currentUser = authFacade.currentUser.filterIsInstance<AuthenticatedUser>().first()
       val strings =
           rule.setContentWithLocalizedStrings {
@@ -124,6 +126,7 @@ class StatefulContestScreenTest {
       val speechFacade = SpeechFacade(FailingSpeechRecognizerFactory)
       val tournamentFacade = TournamentFacade(auth, dataStoreFactory, store, time)
 
+      authFacade.signInWithEmail("email@example.org", "password")
       val user = authFacade.currentUser.filterIsInstance<AuthenticatedUser>().first()
 
       val strings =
@@ -157,6 +160,7 @@ class StatefulContestScreenTest {
       val speechFacade = SpeechFacade(FailingSpeechRecognizerFactory)
       val tournamentFacade = TournamentFacade(auth, dataStoreFactory, store, time)
 
+      authFacade.signInWithEmail("email@example.org", "password")
       val user = authFacade.currentUser.filterIsInstance<AuthenticatedUser>().first()
 
       val strings =

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulHomeTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulHomeTest.kt
@@ -557,6 +557,7 @@ class StatefulHomeTest {
     val speechFacade = SpeechFacade(UnknownCommandSpeechRecognizerFactory)
     val tournamentFacade = TournamentFacade(auth, dataStoreFactory, store, FakeTimeProvider)
 
+    authFacade.signInWithEmail("email@example.org", "password")
     val user = authFacade.currentUser.filterIsInstance<AuthenticatedUser>().first()
 
     val strings =
@@ -592,6 +593,8 @@ class StatefulHomeTest {
     val socialFacade = SocialFacade(auth, store)
     val speechFacade = SpeechFacade(UnknownCommandSpeechRecognizerFactory)
     val tournamentFacade = TournamentFacade(auth, dataStoreFactory, store, FakeTimeProvider)
+
+    authFacade.signInWithEmail("email@example.org", "password")
 
     val user = authFacade.currentUser.filterIsInstance<AuthenticatedUser>().first()
 
@@ -631,6 +634,8 @@ class StatefulHomeTest {
     val socialFacade = SocialFacade(auth, store)
     val speechFacade = SpeechFacade(UnknownCommandSpeechRecognizerFactory)
     val tournamentFacade = TournamentFacade(auth, dataStoreFactory, store, FakeTimeProvider)
+
+    authFacade.signInWithEmail("email@example.org", "password")
 
     val user = authFacade.currentUser.filterIsInstance<AuthenticatedUser>().first()
 

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulProfileScreenTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/StatefulProfileScreenTest.kt
@@ -107,13 +107,12 @@ class StatefulProfileScreenTest {
   @Test
   fun given_userIsLoggedIn_when_clickedOnUnfollowFriend_then_theButtonShouldChangeToFollow() =
       runTest {
-    val auth = buildAuth { user("email@example.org", "password", "userId1") }
     val store = buildStore {
       collection("users") { document("userId2", ProfileDocument(uid = "userId2", name = "user2")) }
     }
 
     val (_, _, strings) =
-        rule.setContentWithTestEnvironment(store = store, auth = auth) {
+        rule.setContentWithTestEnvironment(store = store) {
           StatefulVisitedProfileScreen(
               user = user,
               uid = "userId2",


### PR DESCRIPTION
This PR fixes #408 and fixes the affected tests.

This reproducer is included in the PR :

```kotlin
@Test
fun given_buildAuthWithOneUser_when_getsCurrentUser_then_isEmpty() = runTest {
  val auth = buildAuth { user("alexandre.piveteau@epfl.ch", "password") }
  val result = auth.currentUser.first()
  assertThat(result).isNull()
}