### PR TITLE
Remove the visible divider and improve indicator behaviour on scroll

### DIFF
--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/ContestScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/ContestScreen.kt
@@ -1,5 +1,6 @@
 package ch.epfl.sdp.mobile.ui.tournaments
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.lazy.LazyColumn
@@ -23,7 +24,10 @@ import ch.epfl.sdp.mobile.ui.PawniesIcons
  * @param contentPadding the [PaddingValues] for this screen.
  * @param C the type of the [ContestInfo].
  */
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(
+    ExperimentalFoundationApi::class,
+    ExperimentalMaterialApi::class,
+)
 @Composable
 fun <C : ContestInfo> ContestScreen(
     state: ContestScreenState<C>,
@@ -47,6 +51,7 @@ fun <C : ContestInfo> ContestScreen(
             Contest(
                 contestInfo = contest,
                 onClick = { state.onContestClick(contest) },
+                modifier = Modifier.animateItemPlacement(),
             )
           }
         }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/TournamentDetails.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/TournamentDetails.kt
@@ -294,6 +294,7 @@ private fun DetailsTopBar(
             selectedTabIndex = selected,
             backgroundColor = MaterialTheme.colors.background,
             indicator = {}, // Hide the default indicator.
+            divider = {}, // Hide the default divider.
             edgePadding = 0.dp, // No start padding.
         ) {
           for (index in 0 until count) {

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/TournamentDetails.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/tournaments/TournamentDetails.kt
@@ -28,7 +28,9 @@ import ch.epfl.sdp.mobile.ui.tournaments.TournamentMatch.Result
 import ch.epfl.sdp.mobile.ui.tournaments.TournamentsFinalsRound.Banner
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
+import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 
 /** An interface which represents a match between two players, which both have a name. */
@@ -175,7 +177,7 @@ fun <P : PoolMember, M : TournamentMatch> TournamentDetails(
             onBadgeClick = state::onBadgeClick,
             badgeEnabled = state.badge == BadgeType.Join,
             count = sectionCount,
-            selected = pagerState.currentPage,
+            selected = pagerState.currentPageWithOffset,
             sectionTitle = {
               when (it) {
                 0 -> strings.tournamentsDetailsPools
@@ -507,3 +509,14 @@ private fun DetailsMatch(
     }
   }
 }
+
+/**
+ * A variation of [PagerState.currentPage] which displays the page which is the "most visible" on
+ * the screen.
+ */
+private val PagerState.currentPageWithOffset: Int
+  get() {
+    val page = currentPage + currentPageOffset
+    val max = (pageCount - 1).coerceAtLeast(0) // Handle pageCount = 0.
+    return page.roundToInt().coerceIn(0, max)
+  }


### PR DESCRIPTION
This PR slightly tweaks the visuals of the tab bar of the contests screen for the video. It also adds some simple animations when contests are re-ordered.