### PR TITLE
Add a smooth displacement on pieces

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ar/ChessSceneTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/ui/game/ar/ChessSceneTest.kt
@@ -60,7 +60,8 @@ class ChessSceneTest {
 
       val iterator = simpleBoard.entries.iterator()
       val oldMovePiece = iterator.next()
-      val newMovePiece = oldMovePiece.apply { (Position(4, 4) to value) }.toPair()
+      val newPosition = Position(oldMovePiece.key.x + 1, oldMovePiece.key.y)
+      val newMovePiece = Pair(newPosition, oldMovePiece.value)
 
       val newPiece = (Position(4, 5) to Piece(EnginePiece(White, Rank.Pawn, PieceIdentifier(40))))
       val newBoard = mapOf(newMovePiece, newPiece)

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ArChessBoardScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ArChessBoardScreen.kt
@@ -53,8 +53,16 @@ fun <Piece : ChessBoardState.Piece> ArChessBoardScreen(
               // Place the chess board on the tapped position.
               arSceneView.onTouchAr =
                   { hitResult, _ ->
-                    anchorOrMoveBoard(arSceneView, chessScene, hitResult.createAnchor())
+                    anchorOrMoveBoard(/*arSceneView,*/ chessScene, hitResult.createAnchor())
                   }
+
+              /**
+               * FIXME : Workaround : A strange bug make the animation fail when we add the child
+               * via a function. To solve this quickly, we add the board when is loaded and set it
+               * to invisible. We reset the visibility when the user tap on the screen
+               */
+              arSceneView.addChild(this.boardNode)
+              this.boardNode.isVisible = false
             }
 
         arSceneView
@@ -72,7 +80,7 @@ fun <Piece : ChessBoardState.Piece> ArChessBoardScreen(
  * @param anchor The (new) board's anchor position
  */
 private fun <Piece : ChessBoardState.Piece> anchorOrMoveBoard(
-    arSceneView: ArSceneView,
+    // arSceneView: ArSceneView,
     chessScene: ChessScene<Piece>?,
     anchor: Anchor
 ) {
@@ -80,10 +88,15 @@ private fun <Piece : ChessBoardState.Piece> anchorOrMoveBoard(
   val currentChessScene = chessScene ?: return
 
   currentChessScene.let {
+    // FIXME : Workaround see line 55
+
     // Add only one instance of the node
-    if (!arSceneView.children.contains(it.boardNode)) {
+    /*if (!arSceneView.children.contains(it.boardNode)) {
       arSceneView.addChild(it.boardNode)
-    }
+    }*/
+
+    if (!it.boardNode.isVisible) it.boardNode.isVisible = true
+
     it.boardNode.anchor = anchor
   }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ArChessBoardScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ArChessBoardScreen.kt
@@ -74,7 +74,7 @@ private fun anchorOrMoveBoard(
     anchor: Anchor
 ) {
 
-  // FIXME : Workaround see line 55
+  // FIXME : Workaround see line 117
 
   // Add only one instance of the node
   /*if (!arSceneView.children.contains(boardNode)) {

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ArChessBoardScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/game/ar/ArChessBoardScreen.kt
@@ -21,6 +21,7 @@ private const val BoardScale = 0.2f
 /**
  * Composable used to display a AR chess board
  *
+ * @param Piece the type of the pieces which are present in a board.
  * @param state The state of the game, it's used to track the modification on the game
  * @param modifier modifier the [Modifier] for this composable.
  */
@@ -89,6 +90,7 @@ private fun anchorOrMoveBoard(
 /**
  * Create an instance of [ChessScene] and setup the onTouch callback
  *
+ * @param Piece the type of the pieces which are present in a board.
  * @param context The context of the view
  * @param arSceneView the linked [ArSceneView] where the piece will be display
  * @param startingBoard the board configuration of the beginning


### PR DESCRIPTION
Implement a smooth displacement when the piece changes position. The displacement move first up, to the target position, and then down. 

We have a small bug, but we have a small workaround (See below to have more information). 

Close #369

----
## Workaround

For some reason, if we add the board's node to the scene via a function, the animation doesn't show up. 
The workaround is to add the board's "by default" when the scene is created and set the visibility to false. When the user click on the screen, we set the visibility to true. 
