### PR TITLE
Fix `FakeDataStoreFactory`

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/datastore/Dsl.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/datastore/Dsl.kt
@@ -4,4 +4,4 @@ import ch.epfl.sdp.mobile.infrastructure.persistence.datastore.DataStoreFactory
 import ch.epfl.sdp.mobile.test.infrastructure.persistence.datastore.fake.FakeDataStoreFactory
 
 /** Returns a [DataStoreFactory] with a fake implementation. */
-fun emptyDataStoreFactory(): DataStoreFactory = FakeDataStoreFactory
+fun emptyDataStoreFactory(): DataStoreFactory = FakeDataStoreFactory()

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/datastore/fake/FakeDataStoreFactory.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/datastore/fake/FakeDataStoreFactory.kt
@@ -6,7 +6,7 @@ import ch.epfl.sdp.mobile.infrastructure.persistence.datastore.DataStoreFactory
  * A fake implementation of [DataStoreFactory] which always returns the same underlying instance of
  * [FakePreferencesDataStore].
  */
-object FakeDataStoreFactory : DataStoreFactory {
+class FakeDataStoreFactory : DataStoreFactory {
 
   /** The underlying [FakePreferencesDataStore]. */
   private val preferences = FakePreferencesDataStore()


### PR DESCRIPTION
Due to the factory being an object, a single instance was reused across all the tests. This leads to cross-test interactions, which may make some valid tests fail.