### PR TITLE
Work around `HomeActivity` failing test

### DIFF
--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/datastore/androidx/AndroidXDataStoreFactoryTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/persistence/datastore/androidx/AndroidXDataStoreFactoryTest.kt
@@ -2,26 +2,31 @@ package ch.epfl.sdp.mobile.test.infrastructure.persistence.datastore.androidx
 
 import android.content.Context
 import androidx.datastore.core.DataStore as ActualDataStore
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences as ActualPreferences
 import ch.epfl.sdp.mobile.infrastructure.persistence.datastore.androidx.AndroidXDataStoreFactory
-import io.mockk.*
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class AndroidXDataStoreFactoryTest {
 
   @Test
-  fun given_factory_when_createsDataStore_then_callsGoodMethods() {
+  fun given_factory_when_createsDataStore_then_callsGoodMethods() = runTest {
     val context = mockk<Context>()
-    val factory = AndroidXDataStoreFactory(context)
     val actualDatastore = mockk<ActualDataStore<ActualPreferences>>()
-    mockkObject(PreferenceDataStoreFactory)
+    val factory = AndroidXDataStoreFactory(context) { _, _ -> actualDatastore }
 
-    every { context.applicationContext } returns context
-    every { PreferenceDataStoreFactory.create(any(), any(), any(), any()) } returns actualDatastore
+    val (store, _) = factory.createPreferencesDataStore()
 
-    val (_, _) = factory.createPreferencesDataStore()
+    every { actualDatastore.data } returns emptyFlow()
 
-    verify { PreferenceDataStoreFactory.create(any(), any(), any(), any()) }
+    assertThat(store.data.toList()).isEmpty()
+
+    verify { actualDatastore.data }
   }
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/speech/android/AndroidSpeechRecognizerFactoryTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/infrastructure/speech/android/AndroidSpeechRecognizerFactoryTest.kt
@@ -16,12 +16,12 @@ class AndroidSpeechRecognizerFactoryTest {
     val context = mockk<Context>()
     val factory = AndroidSpeechRecognizerFactory(context)
     val recognizer = mockk<SpeechRecognizer>()
-    mockkStatic(SpeechRecognizer::class)
+    mockkStatic(SpeechRecognizer::class) {
+      every { SpeechRecognizer.createSpeechRecognizer(context) } returns recognizer
 
-    every { SpeechRecognizer.createSpeechRecognizer(context) } returns recognizer
+      factory.createSpeechRecognizer()
 
-    factory.createSpeechRecognizer()
-
-    verify { SpeechRecognizer.createSpeechRecognizer(context) }
+      verify { SpeechRecognizer.createSpeechRecognizer(context) }
+    }
   }
 }

--- a/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/HomeActivityTest.kt
+++ b/mobile/src/androidTest/java/ch/epfl/sdp/mobile/test/state/HomeActivityTest.kt
@@ -1,16 +1,19 @@
 package ch.epfl.sdp.mobile.test.state
 
+import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import ch.epfl.sdp.mobile.state.HomeActivity
+import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
+import org.junit.Test
 
 class HomeActivityTest {
 
   @get:Rule val rule = ActivityScenarioRule(HomeActivity::class.java)
 
-  /** This test is not isolated and causes other test to fail. TODO: create github issue */
-  /**
-   * @Test fun activity_getsCreated() { rule.scenario.moveToState(Lifecycle.State.CREATED)
-   * assertThat(rule.scenario.state).isEqualTo(Lifecycle.State.CREATED) }
-   */
+  @Test
+  fun activity_getsCreated() {
+    rule.scenario.moveToState(Lifecycle.State.CREATED)
+    assertThat(rule.scenario.state).isEqualTo(Lifecycle.State.CREATED)
+  }
 }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/datastore/androidx/AndroidXDataStoreFactory.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/infrastructure/persistence/datastore/androidx/AndroidXDataStoreFactory.kt
@@ -1,25 +1,36 @@
 package ch.epfl.sdp.mobile.infrastructure.persistence.datastore.androidx
 
 import android.content.Context
+import androidx.datastore.core.DataStore as AndroidXDataStore
+import androidx.datastore.preferences.core.Preferences as AndroidXPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import ch.epfl.sdp.mobile.infrastructure.persistence.datastore.DataStore
 import ch.epfl.sdp.mobile.infrastructure.persistence.datastore.DataStoreFactory
 import ch.epfl.sdp.mobile.infrastructure.persistence.datastore.KeyFactory
 import ch.epfl.sdp.mobile.infrastructure.persistence.datastore.Preferences
+import kotlin.reflect.KProperty
 
 /** The datastore file name. */
 private const val DefaultDatastoreFileName = "preferences"
-
-/** The actual underlying preferences data store. */
-private val Context.dataStore by preferencesDataStore(DefaultDatastoreFileName)
 
 /**
  * An implementation of a [DataStoreFactory] which is based on the AndroidX library.
  *
  * @param context the underlying [Context].
+ * @param toDatastore a function which maps the [Context] and the [KProperty] to the actual
+ * [AndroidXDataStore] instance. This behavior is provided as a function to allow for mocking.
  */
-class AndroidXDataStoreFactory(private val context: Context) : DataStoreFactory {
+class AndroidXDataStoreFactory(
+    private val context: Context,
+    toDatastore: (Context, KProperty<*>) -> AndroidXDataStore<AndroidXPreferences> = { c, p ->
+      preferencesDataStore((DefaultDatastoreFileName)).getValue(c, p)
+    }
+) : DataStoreFactory {
+
+  /** The underlying [AndroidXDataStore]. */
+  private val actualDatastore: AndroidXDataStore<AndroidXPreferences> =
+      toDatastore(context, this::actualDatastore)
 
   override fun createPreferencesDataStore(): Pair<DataStore<Preferences>, KeyFactory> =
-      AndroidXPreferencesDataStore(context.dataStore) to AndroidXKeyFactory
+      AndroidXPreferencesDataStore(actualDatastore) to AndroidXKeyFactory
 }


### PR DESCRIPTION
This PR works around the bug in `Mockk` issue which makes static function calls unusable after they've been mocked once.

Additionally, it fixes some unmock calls missing for some of the existing tests.