### PR TITLE
Strengthen en-passant rules constaints for puzzles

### DIFF
--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/engine/rules/PawnRules.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/engine/rules/PawnRules.kt
@@ -103,6 +103,7 @@ object PawnRules : Rules {
     if (position.y != enPassantRow(color)) return
     for (sideDelta in listOf(CardinalPoints.E, CardinalPoints.W)) {
       val target = position + direction(color) + sideDelta
+      if (!get(target).isNone) continue
       val adversaryPosition = position + sideDelta
       val adversary = get(adversaryPosition)
       if (adversary.isNone || adversary.color == color || adversary.rank != Pawn) continue

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/engine/rules/PawnRules.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/application/chess/engine/rules/PawnRules.kt
@@ -89,8 +89,18 @@ object PawnRules : Rules {
     }
   }
 
+  /**
+   * The row at which a pawn must be located for it to be allowed to perform an en-passant take.
+   *
+   * @param color the color of the pawn.
+   * @return the row index.
+   */
+  private fun enPassantRow(color: Color): Int =
+      startRow(color.other()) + direction(color.other()).y * 2
+
   /** Takes the adversary pawns en-passant. */
   private fun ActionScope.enPassant(color: Color, position: Position) {
+    if (position.y != enPassantRow(color)) return
     for (sideDelta in listOf(CardinalPoints.E, CardinalPoints.W)) {
       val target = position + direction(color) + sideDelta
       val adversaryPosition = position + sideDelta


### PR DESCRIPTION
This PR fixes a problem I encountered while playing some of the provided puzzles.

In some rare cases, the en-passant behaviour could be proposed to pawns in puzzles when they were not located on the right row. This caused a problem for some specific puzzles if there was a piece located right behind the pawn which could be taken en-passant, since multiple `Move` would then be available for the pawn (both the en-passant, or the take of the piece behind). As a reminder, in case of ambiguous moves which are not promotions, the viewmodel simply drops the user action since it assumes there was an error in the engine.

This patch strengthens the en-passant conditions to make sure the ambiguous cases are not possible anymore, by enforcing that en-passant happens on a specific row, and that the target position of the "taking" pawn is free.