### PR TITLE
Improve scrolling performance in `UserScreen`

### DIFF
--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulSettingsScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulSettingsScreen.kt
@@ -108,7 +108,13 @@ fun StatefulSettingsScreen(
             currentonEditLanguageClick,
         )
       }
-  SettingsScreen(state, modifier, contentPadding)
+  SettingsScreen(
+      state = state,
+      modifier = modifier,
+      contentPadding = contentPadding,
+      matchKey = { it.uid },
+      puzzleKey = { it.uid },
+  )
 }
 
 /** Class of available callback actions in the settings screen. */

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulVisitedProfileScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/state/StatefulVisitedProfileScreen.kt
@@ -107,7 +107,13 @@ fun StatefulVisitedProfileScreen(
       remember(actions, profile, chessFacade, scope, socialFacade) {
         FetchedUserProfileScreenState(user, profile, actions, chessFacade, scope)
       }
-  ProfileScreen(state, modifier, contentPadding)
+  ProfileScreen(
+      state = state,
+      modifier = modifier,
+      contentPadding = contentPadding,
+      matchKey = { it.uid },
+      puzzleKey = { it.uid },
+  )
 }
 
 private object EmptyProfile : Profile {

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileScreen.kt
@@ -27,12 +27,16 @@ import ch.epfl.sdp.mobile.ui.social.ChessMatch
  * @param state state of the ProfileScreen.
  * @param modifier the [Modifier] for this composable.
  * @param contentPadding the [PaddingValues] to apply to this screen.
+ * @param matchKey the key for each match item.
+ * @param puzzleKey the key for each puzzle item.
  */
 @Composable
 fun <C : ChessMatch, P : PuzzleInfo> ProfileScreen(
     state: VisitedProfileScreenState<C, P>,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
+    matchKey: ((C) -> Any)? = null,
+    puzzleKey: ((P) -> Any)? = null,
 ) {
   val lazyColumnState = rememberLazyListState()
   val tabBarState = rememberProfileTabBarState(state.pastGamesCount, state.solvedPuzzlesCount)
@@ -56,7 +60,10 @@ fun <C : ChessMatch, P : PuzzleInfo> ProfileScreen(
       onPuzzleClick = state::onPuzzleClick,
       lazyColumnState = lazyColumnState,
       contentPadding = contentPadding,
-      modifier = modifier)
+      modifier = modifier,
+      matchKey = matchKey,
+      puzzleKey = puzzleKey,
+  )
 }
 
 /**

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileScreen.kt
@@ -1,13 +1,14 @@
 package ch.epfl.sdp.mobile.ui.profile
 
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -35,8 +36,9 @@ fun <C : ChessMatch, P : PuzzleInfo> ProfileScreen(
 ) {
   val lazyColumnState = rememberLazyListState()
   val tabBarState = rememberProfileTabBarState(state.pastGamesCount, state.solvedPuzzlesCount)
-  val targetElevation = if (lazyColumnState.firstVisibleItemIndex >= 1) 4.dp else 0.dp
-  val elevation by animateDpAsState(targetElevation)
+  val targetElevation by remember {
+    derivedStateOf { if (lazyColumnState.firstVisibleItemIndex >= 1) 4.dp else 0.dp }
+  }
 
   UserScreen(
       header = { ProfileHeader(state, Modifier.padding(vertical = 16.dp).fillMaxWidth()) },
@@ -44,7 +46,7 @@ fun <C : ChessMatch, P : PuzzleInfo> ProfileScreen(
         ProfileTabBar(
             state = tabBarState,
             modifier = Modifier.fillMaxWidth(),
-            elevation = elevation,
+            elevation = targetElevation,
         )
       },
       tabBarState = tabBarState,

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileTabBar.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/ProfileTabBar.kt
@@ -1,6 +1,7 @@
 package ch.epfl.sdp.mobile.ui.profile
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -149,10 +150,11 @@ fun ProfileTabBar(
     elevation: Dp = 0.dp,
 ) {
   val strings = LocalLocalizedStrings.current
+  val currentElevation by animateDpAsState(elevation)
   Surface(
       modifier = modifier,
       color = backgroundColor,
-      elevation = elevation,
+      elevation = currentElevation,
   ) {
     Row(
         horizontalArrangement = Arrangement.Center,

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/UserScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/profile/UserScreen.kt
@@ -31,6 +31,8 @@ import ch.epfl.sdp.mobile.ui.social.ChessMatch
  * [ChessMatch] is clicked.
  * @param modifier the [Modifier] for this composable.
  * @param contentPadding the [PaddingValues] for this screen.
+ * @param matchKey the key for each match item.
+ * @param puzzleKey the key for each puzzle item.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -45,6 +47,8 @@ fun <C : ChessMatch, P : PuzzleInfo> UserScreen(
     lazyColumnState: LazyListState,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
+    matchKey: ((C) -> Any)? = null,
+    puzzleKey: ((P) -> Any)? = null,
 ) {
 
   LazyColumn(
@@ -58,10 +62,25 @@ fun <C : ChessMatch, P : PuzzleInfo> UserScreen(
     stickyHeader { profileTabBar() }
     when (tabBarState.currentTab) {
       ProfileTabBarState.Tab.PastGames ->
-          items(matches) { match -> Match(match, ChessIcons.WhiteKing, { onMatchClick(match) }) }
+          items(
+              items = matches,
+              key = matchKey,
+          ) { match ->
+            Match(
+                onClick = { onMatchClick(match) },
+                match = match,
+                icon = ChessIcons.WhiteKing,
+            )
+          }
       ProfileTabBarState.Tab.Puzzles ->
-          items(puzzles) { puzzle ->
-            PuzzleListInfo(puzzleInfo = puzzle, onClick = { onPuzzleClick(puzzle) })
+          items(
+              items = puzzles,
+              key = puzzleKey,
+          ) { puzzle ->
+            PuzzleListInfo(
+                puzzleInfo = puzzle,
+                onClick = { onPuzzleClick(puzzle) },
+            )
           }
     }
   }

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/setting/SettingScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/setting/SettingScreen.kt
@@ -35,12 +35,16 @@ import ch.epfl.sdp.mobile.ui.social.ChessMatch
  * @param state state of the ProfileScreen.
  * @param modifier the [Modifier] for this composable.
  * @param contentPadding the [PaddingValues] for this screen.
+ * @param matchKey the key for each match item.
+ * @param puzzleKey the key for each puzzle item.
  */
 @Composable
 fun <C : ChessMatch, P : PuzzleInfo> SettingsScreen(
     state: SettingScreenState<C, P>,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
+    matchKey: ((C) -> Any)? = null,
+    puzzleKey: ((P) -> Any)? = null,
 ) {
   val lazyColumnState = rememberLazyListState()
   val tabBarState = rememberProfileTabBarState(state.pastGamesCount, state.solvedPuzzlesCount)
@@ -69,6 +73,8 @@ fun <C : ChessMatch, P : PuzzleInfo> SettingsScreen(
       lazyColumnState = lazyColumnState,
       modifier = modifier.fillMaxSize(),
       contentPadding = contentPadding,
+      matchKey = matchKey,
+      puzzleKey = puzzleKey,
   )
 }
 

--- a/mobile/src/main/java/ch/epfl/sdp/mobile/ui/setting/SettingScreen.kt
+++ b/mobile/src/main/java/ch/epfl/sdp/mobile/ui/setting/SettingScreen.kt
@@ -1,6 +1,5 @@
 package ch.epfl.sdp.mobile.ui.setting
 
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -9,7 +8,9 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -43,8 +44,9 @@ fun <C : ChessMatch, P : PuzzleInfo> SettingsScreen(
 ) {
   val lazyColumnState = rememberLazyListState()
   val tabBarState = rememberProfileTabBarState(state.pastGamesCount, state.solvedPuzzlesCount)
-  val targetElevation = if (lazyColumnState.firstVisibleItemIndex >= 1) 4.dp else 0.dp
-  val elevation by animateDpAsState(targetElevation)
+  val targetElevation by remember {
+    derivedStateOf { if (lazyColumnState.firstVisibleItemIndex >= 1) 4.dp else 0.dp }
+  }
   UserScreen(
       header = {
         SettingHeader(
@@ -56,7 +58,7 @@ fun <C : ChessMatch, P : PuzzleInfo> SettingsScreen(
         ProfileTabBar(
             state = tabBarState,
             modifier = Modifier.fillMaxWidth(),
-            elevation = elevation,
+            elevation = targetElevation,
         )
       },
       tabBarState = tabBarState,


### PR DESCRIPTION
This PR improves scrolling performance in the list of matches and puzzles for profiles. This is done in two ways :

- the `LazyColumn` state is no longer read in the composition but rather as a `derivedStateOf`, reducing and narrowing the scope of recompositions to animate the elevation of the toolbars;
- the matches and puzzles are now keyed, which may help with item re-using.